### PR TITLE
Adding support to build definitions that edit the 'externalResolvers' task key

### DIFF
--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -33,7 +33,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override lazy val projectSettings = Seq(
-    credentials ++= buildCredentials(credentials.value, resolvers.value, streams.value.log),
+    credentials ++= buildCredentials(credentials.value, externalResolvers.value, streams.value.log),
 
     // Fix for https://github.com/coursier/coursier/issues/1649
     csrConfiguration := updateCoursierConf(


### PR DESCRIPTION
Hey thanks for this plugin!

The "resolvers" settings key is for user defined extra resolvers. According to SBT documentation [here](https://www.scala-sbt.org/1.x/docs/Library-Management.html#Override+default+resolvers), the only way of removing the default resolvers and use only the user defined ones is if the task key `externalResolvers` is redefined.

I made this change and tested in build definitions that do the regular `resolvers += ...` and in build definitions that redefine `extraResolvers := ...`. In both cases, it seems to work now.