### PR TITLE
fix: WorkloadIdentityCredential eager-build regression in v0.0.8 + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,36 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - run: sbt -batch test
+      - run: sbt -batch clean coverage test coverageReport
+      - name: Coverage summary
+        if: always()
+        env:
+          MATRIX_JAVA: ${{ matrix.java }}
+        run: |
+          python3 - <<'EOF'
+          import xml.etree.ElementTree as ET, glob, os
+          reports = glob.glob('target/scala-*/sbt-*/scoverage-report/scoverage.xml')
+          if not reports:
+              exit(0)
+          root = ET.parse(reports[0]).getroot()
+          a = root.attrib
+          stmt_total = int(a.get('statement-count', 0))
+          stmt_done  = int(a.get('statements-invoked', 0))
+          stmt_pct   = a.get('statement-rate', '0')
+          branch_pct = a.get('branch-rate', '0')
+          rows = (
+              f"| Statement | {stmt_pct}% ({stmt_done}/{stmt_total}) |\n"
+              f"| Branch    | {branch_pct}% |\n"
+          )
+          jv = os.environ.get('MATRIX_JAVA', '?')
+          summary = f"## Coverage (Java {jv})\n| Metric | Coverage |\n|---|---|\n{rows}"
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write(summary)
+          EOF
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scoverage-report-java-${{ matrix.java }}
+          path: target/scala-*/sbt-*/scoverage-report/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: sbt
+      # `cache: sbt` above covers ~/.sbt and ~/.ivy2/cache but not the Coursier cache,
+      # which is where sbt 1.3+ resolves most artifacts (azure-identity + transitive
+      # netty/reactor, scalatest, scoverage runtime, etc.). Cache it explicitly so the
+      # JDK matrix doesn't re-download on every job.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/coursier
+          key: coursier-${{ runner.os }}-${{ hashFiles('build.sbt', 'project/plugins.sbt', 'project/build.properties') }}
+          restore-keys: |
+            coursier-${{ runner.os }}-
       - uses: sbt/setup-sbt@v1
       - run: sbt -batch clean coverage test coverageReport
       - name: Coverage summary
@@ -29,10 +39,13 @@ jobs:
         run: |
           python3 - <<'EOF'
           import xml.etree.ElementTree as ET, glob, os
-          reports = glob.glob('target/scala-*/sbt-*/scoverage-report/scoverage.xml')
+          # Sort for deterministic selection when multiple reports exist (e.g. future
+          # cross-sbt-version builds). Today this glob matches exactly one file.
+          reports = sorted(glob.glob('target/scala-*/sbt-*/scoverage-report/scoverage.xml'))
           if not reports:
               exit(0)
-          root = ET.parse(reports[0]).getroot()
+          report = reports[0]
+          root = ET.parse(report).getroot()
           a = root.attrib
           stmt_total = int(a.get('statement-count', 0))
           stmt_done  = int(a.get('statements-invoked', 0))
@@ -43,7 +56,13 @@ jobs:
               f"| Branch    | {branch_pct}% |\n"
           )
           jv = os.environ.get('MATRIX_JAVA', '?')
-          summary = f"## Coverage (Java {jv})\n| Metric | Coverage |\n|---|---|\n{rows}"
+          summary = (
+              f"## Coverage (Java {jv})\n"
+              f"_Source: `{report}`"
+              + (f" (1 of {len(reports)} reports — alphabetically first)" if len(reports) > 1 else "")
+              + "_\n"
+              f"| Metric | Coverage |\n|---|---|\n{rows}"
+          )
           with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
               f.write(summary)
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 17, 21]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - run: sbt -batch test

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,21 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
 // Exclude integration tests (tagged as Slow) by default
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.scalatest.tagobjects.Slow")
 
+// Serialize test suite execution. Multiple suites mutate the JVM-global
+// `org.slf4j.simpleLogger.log.com.azure.identity` system property — both
+// the plugin's own counted-set acquire/release in `CredentialsBuilderSpec`
+// and direct save/restore in `AzureDevOpsCredentialsPluginSpec`'s
+// `initializeAzureIdentityLogSuppression` tests. sbt's default
+// (parallelExecution := true) runs different suites in parallel, which
+// opens a cross-suite race window where one suite's clearProperty fires
+// between another suite's setProperty and acquire, leaving the acquire's
+// first-acquirer save snapshotting None instead of the real value. The
+// race window is small (Mono.just resolves in microseconds) but real,
+// and on a ~66-test suite that finishes in ~1s the cost of serializing
+// is negligible. Future-proofs against any third spec adding similar
+// JVM-global-state mutations.
+Test / parallelExecution := false
+
 // Coverage gate matches current coverage exactly. Any regression in test
 // discipline must be addressed with a new test, or — if a statement is
 // genuinely unreachable from unit tests — with a `$COVERAGE-OFF$` marker.

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,9 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
 // Exclude integration tests (tagged as Slow) by default
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.scalatest.tagobjects.Slow")
 
-// Coverage thresholds — keep them tight so regressions in test discipline fail CI.
-coverageMinimumStmtTotal := 95
-coverageMinimumBranchTotal := 95
+// Coverage gate matches current coverage exactly. Any regression in test
+// discipline must be addressed with a new test, or — if a statement is
+// genuinely unreachable from unit tests — with a `$COVERAGE-OFF$` marker.
+coverageMinimumStmtTotal := 100
+coverageMinimumBranchTotal := 100
 coverageFailOnMinimum := true

--- a/build.sbt
+++ b/build.sbt
@@ -15,3 +15,8 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
 
 // Exclude integration tests (tagged as Slow) by default
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.scalatest.tagobjects.Slow")
+
+// Coverage thresholds — keep them tight so regressions in test discipline fail CI.
+coverageMinimumStmtTotal := 95
+coverageMinimumBranchTotal := 95
+coverageFailOnMinimum := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -24,7 +24,7 @@ import scala.util.control.NonFatal
 import scala.xml.XML
 
 import sbt._
-import sbt.internal.util.ManagedLogger
+import sbt.util.Logger
 import Keys._
 
 import lmcoursier.CoursierConfiguration
@@ -158,6 +158,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     }
   }
 
+  // $COVERAGE-OFF$ sbt task wiring — exercised only inside a real sbt build, not unit-testable
   override lazy val projectSettings = Seq(
     credentials ++= new CredentialsBuilder(streams.value.log)
       .buildCredentials(credentials.value, externalResolvers.value),
@@ -168,8 +169,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     updateClassifiers / csrConfiguration :=
         csrConfiguration.value.withClassifiers(Vector("sources")).withHasClassifiers(true)
   )
+  // $COVERAGE-ON$
 
-  class CredentialsBuilder(log: ManagedLogger) {
+  class CredentialsBuilder(log: Logger) {
     def buildCredentials(
         existingCredentials: Seq[Credentials],
         resolvers: Seq[Resolver]): Seq[Credentials] = {
@@ -179,6 +181,13 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
         resolvers)
       credentialsFromMavenSettings ++ generatedCredentials
     }
+
+    /** Location of the Maven settings.xml file. Overridable for testing. */
+    protected def mavenSettingsFile: File = new File(sbt.io.Path.userHome, ".m2/settings.xml")
+
+    /** Create the TokenCredential chain used by [[getTokenImpl]]. Overridable
+      * for testing so the Azure SDK does not have to be exercised. */
+    protected def newCredential(): TokenCredential = AzureDevOpsCredentialsPlugin.createCredential()
 
     private def buildCredentialsWithAccessToken(
         existingCredentials: Seq[Credentials],
@@ -218,7 +227,8 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       maybeOrg
     }
 
-    private def getRealm(uri: URI): Option[String] = {
+    /** Discover the BASIC auth realm advertised by the feed. Overridable for testing. */
+    protected def getRealm(uri: URI): Option[String] = {
       try {
         val headers = AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
         val realm = headers.collectFirst {
@@ -238,7 +248,8 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
     private var cachedToken: Option[Option[String]] = None
 
-    private def getToken(): Option[String] = synchronized {
+    /** Acquire and cache an Azure DevOps access token. Overridable for testing. */
+    protected def getToken(): Option[String] = synchronized {
       if (!cachedToken.isDefined) {
         cachedToken = Some(getTokenImpl())
       }
@@ -253,7 +264,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       val previousLevel = Option(System.getProperty(AzureIdentityLogProperty))
       System.setProperty(AzureIdentityLogProperty, "off")
       try {
-        val credential = createCredential()
+        val credential = newCredential()
         val request = new TokenRequestContext().addScopes(AzureDevOpsScope)
         val token = credential.getToken(request).block()
         if (token != null) {
@@ -278,7 +289,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
     private def buildCredentialsFromMavenSettings(resolvers: Seq[Resolver]): Seq[Credentials] = {
       // TODO: support M2_HOME
-      val settingsFile = new File(sbt.io.Path.userHome, ".m2/settings.xml")
+      val settingsFile = mavenSettingsFile
       log.debug(s"trying to load credentials from $settingsFile")
       if (!settingsFile.exists) {
         log.debug(s"file not found: $settingsFile")
@@ -316,7 +327,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   }
 
   // Fix for https://github.com/coursier/coursier/issues/1649
-  private def updateCoursierConf(
+  private[sbt] def updateCoursierConf(
       conf: CoursierConfiguration,
       resolvers: Seq[Resolver],
       credentials: Seq[Credentials]) = {

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -262,28 +262,35 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       // Suppress Azure Identity logging during token acquisition. ChainedTokenCredential
       // logs [ERROR] for each provider that fails, which are expected failures — not all
       // providers are available in all environments.
-      val previousLevel = Option(System.getProperty(AzureIdentityLogProperty))
-      System.setProperty(AzureIdentityLogProperty, "off")
-      try {
-        val credential = newCredential()
-        val request = new TokenRequestContext().addScopes(AzureDevOpsScope)
-        val token = credential.getToken(request).block()
-        if (token != null) {
-          log.debug("access token created")
-          Some(token.getToken())
-        } else {
-          log.warn(s"failed to get access token (getToken() returned null)")
-          None
-        }
-      } catch {
-        case NonFatal(e) =>
-          log.warn(s"failed to get access token. Did you forget to run `az login`?")
-          log.debug(e.toString())
-          None
-      } finally {
-        previousLevel match {
-          case Some(level) => System.setProperty(AzureIdentityLogProperty, level)
-          case None => System.clearProperty(AzureIdentityLogProperty)
+      //
+      // Lock is at object (singleton) scope, not `this`, because the system property is
+      // JVM-wide global state. Without this, two CredentialsBuilder instances on different
+      // threads (e.g. multi-project sbt builds resolving credentials in parallel) could
+      // interleave save/set/restore and leave the property pinned to "off" indefinitely.
+      AzureDevOpsCredentialsPlugin.synchronized {
+        val previousLevel = Option(System.getProperty(AzureIdentityLogProperty))
+        System.setProperty(AzureIdentityLogProperty, "off")
+        try {
+          val credential = newCredential()
+          val request = new TokenRequestContext().addScopes(AzureDevOpsScope)
+          val token = credential.getToken(request).block()
+          if (token != null) {
+            log.debug("access token created")
+            Some(token.getToken())
+          } else {
+            log.warn(s"failed to get access token (getToken() returned null)")
+            None
+          }
+        } catch {
+          case NonFatal(e) =>
+            log.warn(s"failed to get access token. Did you forget to run `az login`?")
+            log.debug(e.toString())
+            None
+        } finally {
+          previousLevel match {
+            case Some(level) => System.setProperty(AzureIdentityLogProperty, level)
+            case None => System.clearProperty(AzureIdentityLogProperty)
+          }
         }
       }
     }

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -110,6 +110,16 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     host != null && (host.endsWith("pkgs.visualstudio.com") || host == "pkgs.dev.azure.com")
   }
 
+  /** Return the explicit port from `uri`, or the scheme default (443 for `https`,
+    * 80 for everything else). Extracted as a pure helper for direct unit testing —
+    * exercising it through [[headRequestHeaders]] would require an actual socket
+    * round-trip and only verifies behavior tautologically (any port choice fails
+    * the same way against an unresponsive address). */
+  private[sbt] def defaultPort(uri: URI): Int =
+    if (uri.getPort >= 0) uri.getPort
+    else if (uri.getScheme == "https") 443
+    else 80
+
   /** Send an unauthenticated HEAD request and return the response headers.
     *
     * Uses a raw socket instead of HttpURLConnection to avoid triggering
@@ -117,8 +127,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * credentials" error messages when the server responds with 401. */
   private[sbt] def headRequestHeaders(uri: URI): Seq[(String, String)] = {
     val host = uri.getHost
-    val port = if (uri.getPort >= 0) uri.getPort else
-      (if (uri.getScheme == "https") 443 else 80)
+    val port = defaultPort(uri)
     val path = Option(uri.getRawPath).filter(_.nonEmpty).getOrElse("/")
     val rawSocket = new Socket()
     try {

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -254,11 +254,23 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     host != null && (host.endsWith("pkgs.visualstudio.com") || host == "pkgs.dev.azure.com")
   }
 
-  /** Return the explicit port from `uri`, or the scheme default (443 for `https`,
-    * 80 for everything else). Extracted as a pure helper for direct unit testing —
-    * exercising it through [[headRequestHeaders]] would require an actual socket
-    * round-trip and only verifies behavior tautologically (any port choice fails
-    * the same way against an unresponsive address). */
+  /** Return the effective HTTP/HTTPS port for `uri`: the explicit port when
+    * set, otherwise 443 for `https` and 80 for everything else.
+    *
+    * Despite the general-sounding name, this is intentionally an http/https
+    * helper, not a scheme-aware lookup. It exists only because
+    * [[headRequestHeaders]] needs a port to open a socket against MavenRepo
+    * resolvers, which the rest of the plugin filters to http/https-only URIs
+    * via [[isAzureDevOpsHost]] (no `ftp:`/`file:`/`ssh:` resolver reaches
+    * here in practice). The `else 80` branch is the gate-coverage tail that
+    * keeps the helper total — not a canonical default for `ftp` or any
+    * other non-http(s) scheme, where 80 is wrong (ftp's canonical port is
+    * 21, ssh's is 22, etc.).
+    *
+    * Extracted as a pure helper for direct unit testing — exercising it
+    * through [[headRequestHeaders]] would require an actual socket
+    * round-trip and only verifies behavior tautologically (any port choice
+    * fails the same way against an unresponsive address). */
   private[chungmin] def defaultPort(uri: URI): Int =
     if (uri.getPort >= 0) uri.getPort
     else if (uri.getScheme == "https") 443

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -57,9 +57,10 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     *
     * WorkloadIdentityCredentialBuilder.build() validates eagerly and throws
     * IllegalArgumentException unless its clientId / tenantId / tokenFilePath are
-    * all set. Unlike DefaultAzureCredential, it does NOT auto-read AZURE_CLIENT_ID
-    * / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE from the environment, so we
-    * populate them ourselves. When those env vars are absent (the common case on
+    * all set to non-null AND non-empty values. Unlike DefaultAzureCredential,
+    * it does NOT auto-read AZURE_CLIENT_ID / AZURE_TENANT_ID /
+    * AZURE_FEDERATED_TOKEN_FILE from the environment, so we populate them
+    * ourselves. When those env vars are absent or empty (the common case on
     * dev workstations) we skip the credential entirely; otherwise the chain
     * assembly would fail before AzureCli is ever tried.
     *
@@ -71,9 +72,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       .addLast(new AzurePowerShellCredentialBuilder().build())
       .addLast(new EnvironmentCredentialBuilder().build())
     for {
-      clientId <- env.get("AZURE_CLIENT_ID")
-      tenantId <- env.get("AZURE_TENANT_ID")
-      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE")
+      clientId  <- env.get("AZURE_CLIENT_ID").filter(_.nonEmpty)
+      tenantId  <- env.get("AZURE_TENANT_ID").filter(_.nonEmpty)
+      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE").filter(_.nonEmpty)
     } {
       builder.addLast(
         new WorkloadIdentityCredentialBuilder()

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -53,13 +53,37 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
   /** Create a credential chain that prioritizes user credentials over managed identity.
     * Order: AzureCli → AzurePowerShell → Environment → WorkloadIdentity → ManagedIdentity.
-    * This ensures user's az login or Azure PowerShell session is preferred over VM identity. */
-  private[sbt] def createCredential(): TokenCredential = {
-    new ChainedTokenCredentialBuilder()
+    * This ensures user's az login or Azure PowerShell session is preferred over VM identity.
+    *
+    * WorkloadIdentityCredentialBuilder.build() validates eagerly and throws
+    * IllegalArgumentException unless its clientId / tenantId / tokenFilePath are
+    * all set. Unlike DefaultAzureCredential, it does NOT auto-read AZURE_CLIENT_ID
+    * / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE from the environment, so we
+    * populate them ourselves. When those env vars are absent (the common case on
+    * dev workstations) we skip the credential entirely; otherwise the chain
+    * assembly would fail before AzureCli is ever tried.
+    *
+    * The env parameter exists for testability — production callers should use
+    * the default. */
+  private[sbt] def createCredential(env: Map[String, String] = sys.env): TokenCredential = {
+    val builder = new ChainedTokenCredentialBuilder()
       .addLast(new AzureCliCredentialBuilder().build())
       .addLast(new AzurePowerShellCredentialBuilder().build())
       .addLast(new EnvironmentCredentialBuilder().build())
-      .addLast(new WorkloadIdentityCredentialBuilder().build())
+    for {
+      clientId <- env.get("AZURE_CLIENT_ID")
+      tenantId <- env.get("AZURE_TENANT_ID")
+      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE")
+    } {
+      builder.addLast(
+        new WorkloadIdentityCredentialBuilder()
+          .clientId(clientId)
+          .tenantId(tenantId)
+          .tokenFilePath(tokenFile)
+          .build()
+      )
+    }
+    builder
       .addLast(new ManagedIdentityCredentialBuilder().build())
       .build()
   }

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -59,8 +59,15 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
   /** System property to control Azure Identity SDK logging.
     * Set to "off" during token acquisition to suppress expected [ERROR] messages
-    * from ChainedTokenCredential trying each provider in sequence. */
-  private val AzureIdentityLogProperty = "org.slf4j.simpleLogger.log.com.azure.identity"
+    * from ChainedTokenCredential trying each provider in sequence.
+    *
+    * Exposed as `private[chungmin]` (not pure `private`) so test sites can
+    * reference the property name through the constant instead of re-declaring
+    * the string literal in every test that touches the property. Keeping the
+    * literal in one place means an Azure-SDK-driven rename (or an SLF4J
+    * binding-key change) wouldn't silently leave tests asserting against a
+    * stale property name. */
+  private[chungmin] val AzureIdentityLogProperty = "org.slf4j.simpleLogger.log.com.azure.identity"
 
   /** Set [[AzureIdentityLogProperty]] to `"off"` at plugin classloading if it
     * isn't already set. Defends against the SLF4J SimpleLogger caching

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -51,6 +51,39 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * from ChainedTokenCredential trying each provider in sequence. */
   private val AzureIdentityLogProperty = "org.slf4j.simpleLogger.log.com.azure.identity"
 
+  // Reference-counted suppression of the Azure-identity log-level system property.
+  // The first acquirer saves the previous value and sets the property to "off"; the
+  // last releaser restores it. Counted-set pattern so that multiple in-flight
+  // CredentialsBuilder instances share one suppression window without holding any
+  // lock during the (slow) Azure SDK call — only the brief save+set / restore
+  // boundaries serialize. Synchronized on this private monitor, not on the plugin
+  // object itself, so the lock can't be observed (or coincidentally taken) by
+  // outside code.
+  private val AzureIdentityLogSuppressionLock = new Object
+  private var suppressionCount: Int = 0
+  private var savedAzureIdentityLogLevel: Option[String] = None
+
+  private[sbt] def acquireAzureIdentityLogSuppression(): Unit =
+    AzureIdentityLogSuppressionLock.synchronized {
+      if (suppressionCount == 0) {
+        savedAzureIdentityLogLevel = Option(System.getProperty(AzureIdentityLogProperty))
+        System.setProperty(AzureIdentityLogProperty, "off")
+      }
+      suppressionCount += 1
+    }
+
+  private[sbt] def releaseAzureIdentityLogSuppression(): Unit =
+    AzureIdentityLogSuppressionLock.synchronized {
+      suppressionCount -= 1
+      if (suppressionCount == 0) {
+        savedAzureIdentityLogLevel match {
+          case Some(level) => System.setProperty(AzureIdentityLogProperty, level)
+          case None => System.clearProperty(AzureIdentityLogProperty)
+        }
+        savedAzureIdentityLogLevel = None
+      }
+    }
+
   /** Create a credential chain that prioritizes user credentials over managed identity.
     * Order: AzureCli → AzurePowerShell → Environment → WorkloadIdentity → ManagedIdentity.
     * This ensures user's az login or Azure PowerShell session is preferred over VM identity.
@@ -60,9 +93,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * all set to non-null AND non-empty values. Unlike DefaultAzureCredential,
     * it does NOT auto-read AZURE_CLIENT_ID / AZURE_TENANT_ID /
     * AZURE_FEDERATED_TOKEN_FILE from the environment, so we populate them
-    * ourselves. When those env vars are absent or empty (the common case on
-    * dev workstations) we skip the credential entirely; otherwise the chain
-    * assembly would fail before AzureCli is ever tried.
+    * ourselves. When those env vars are absent, empty, or whitespace-only (the
+    * common case on dev workstations) we skip the credential entirely; otherwise
+    * the chain assembly would fail before AzureCli is ever tried.
     *
     * The env parameter exists for testability — production callers should use
     * the default. */
@@ -72,9 +105,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       .addLast(new AzurePowerShellCredentialBuilder().build())
       .addLast(new EnvironmentCredentialBuilder().build())
     for {
-      clientId  <- env.get("AZURE_CLIENT_ID").filter(_.nonEmpty)
-      tenantId  <- env.get("AZURE_TENANT_ID").filter(_.nonEmpty)
-      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE").filter(_.nonEmpty)
+      clientId  <- env.get("AZURE_CLIENT_ID").filter(_.trim.nonEmpty)
+      tenantId  <- env.get("AZURE_TENANT_ID").filter(_.trim.nonEmpty)
+      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE").filter(_.trim.nonEmpty)
     } {
       builder.addLast(
         new WorkloadIdentityCredentialBuilder()
@@ -272,35 +305,31 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       // logs [ERROR] for each provider that fails, which are expected failures — not all
       // providers are available in all environments.
       //
-      // Lock is at object (singleton) scope, not `this`, because the system property is
-      // JVM-wide global state. Without this, two CredentialsBuilder instances on different
-      // threads (e.g. multi-project sbt builds resolving credentials in parallel) could
-      // interleave save/set/restore and leave the property pinned to "off" indefinitely.
-      AzureDevOpsCredentialsPlugin.synchronized {
-        val previousLevel = Option(System.getProperty(AzureIdentityLogProperty))
-        System.setProperty(AzureIdentityLogProperty, "off")
-        try {
-          val credential = newCredential()
-          val request = new TokenRequestContext().addScopes(AzureDevOpsScope)
-          val token = credential.getToken(request).block()
-          if (token != null) {
-            log.debug("access token created")
-            Some(token.getToken())
-          } else {
-            log.warn(s"failed to get access token (getToken() returned null)")
-            None
-          }
-        } catch {
-          case NonFatal(e) =>
-            log.warn(s"failed to get access token. Did you forget to run `az login`?")
-            log.debug(e.toString())
-            None
-        } finally {
-          previousLevel match {
-            case Some(level) => System.setProperty(AzureIdentityLogProperty, level)
-            case None => System.clearProperty(AzureIdentityLogProperty)
-          }
+      // The suppression is a JVM-wide system property (`AzureIdentityLogProperty`), so
+      // we coordinate via a counted-set on the plugin object: the first acquirer saves
+      // the previous value and sets the property to "off"; the last releaser restores
+      // it. The brief save+set / restore boundaries serialize across threads, but the
+      // SDK call itself runs without any plugin-level lock, so multi-project sbt builds
+      // can fetch tokens in parallel.
+      AzureDevOpsCredentialsPlugin.acquireAzureIdentityLogSuppression()
+      try {
+        val credential = newCredential()
+        val request = new TokenRequestContext().addScopes(AzureDevOpsScope)
+        val token = credential.getToken(request).block()
+        if (token != null) {
+          log.debug("access token created")
+          Some(token.getToken())
+        } else {
+          log.warn(s"failed to get access token (getToken() returned null)")
+          None
         }
+      } catch {
+        case NonFatal(e) =>
+          log.warn(s"failed to get access token. Did you forget to run `az login`?")
+          log.debug(e.toString())
+          None
+      } finally {
+        AzureDevOpsCredentialsPlugin.releaseAzureIdentityLogSuppression()
       }
     }
 

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -84,6 +84,15 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       }
     }
 
+  /** Normalize an env-var value: trim surrounding whitespace and return
+    * `Some(trimmed)` when the result is non-empty; `None` for absent, empty,
+    * or whitespace-only values. Extracted as a pure helper so the trim+filter
+    * behavior is directly unit-testable (verifying via [[createCredential]]
+    * alone would be tautological — the SDK builder accepts padded values, so
+    * a chain-assembly assertion doesn't prove the trim ran). */
+  private[sbt] def envValue(env: Map[String, String], key: String): Option[String] =
+    env.get(key).map(_.trim).filter(_.nonEmpty)
+
   /** Create a credential chain that prioritizes user credentials over managed identity.
     * Order: AzureCli → AzurePowerShell → Environment → WorkloadIdentity → ManagedIdentity.
     * This ensures user's az login or Azure PowerShell session is preferred over VM identity.
@@ -93,9 +102,13 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * all set to non-null AND non-empty values. Unlike DefaultAzureCredential,
     * it does NOT auto-read AZURE_CLIENT_ID / AZURE_TENANT_ID /
     * AZURE_FEDERATED_TOKEN_FILE from the environment, so we populate them
-    * ourselves. When those env vars are absent, empty, or whitespace-only (the
-    * common case on dev workstations) we skip the credential entirely; otherwise
-    * the chain assembly would fail before AzureCli is ever tried.
+    * ourselves via [[envValue]]. When those env vars are absent, empty, or
+    * whitespace-only (the common case on dev workstations) we skip the
+    * credential entirely; otherwise the chain assembly would fail before
+    * AzureCli is ever tried. Padded values (e.g. a trailing newline from a
+    * broken env-template substitution) are trimmed before reaching the SDK,
+    * since the SDK accepts them at build time but they'd fail at getToken
+    * time and add noise to the chain.
     *
     * The env parameter exists for testability — production callers should use
     * the default. */
@@ -105,9 +118,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       .addLast(new AzurePowerShellCredentialBuilder().build())
       .addLast(new EnvironmentCredentialBuilder().build())
     for {
-      clientId  <- env.get("AZURE_CLIENT_ID").filter(_.trim.nonEmpty)
-      tenantId  <- env.get("AZURE_TENANT_ID").filter(_.trim.nonEmpty)
-      tokenFile <- env.get("AZURE_FEDERATED_TOKEN_FILE").filter(_.trim.nonEmpty)
+      clientId  <- envValue(env, "AZURE_CLIENT_ID")
+      tenantId  <- envValue(env, "AZURE_TENANT_ID")
+      tokenFile <- envValue(env, "AZURE_FEDERATED_TOKEN_FILE")
     } {
       builder.addLast(
         new WorkloadIdentityCredentialBuilder()

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -84,6 +84,18 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       }
     }
 
+  /** Snapshot of the suppression counter for test-isolation assertions.
+    * The counted-set state ([[suppressionCount]] and
+    * [[savedAzureIdentityLogLevel]]) is JVM-global and persists across tests
+    * within the same JVM. A future test (or a refactor of an existing one)
+    * that leaks an unmatched acquire would otherwise manifest as a confusing
+    * failure in a downstream test — the symptom (a wrong property value)
+    * surfaces several tests away from the leak source. Exposed as
+    * `private[sbt]` so test code can assert `count == 0` between tests and
+    * pin any future leak to its actual source. */
+  private[sbt] def suppressionCountForTesting: Int =
+    AzureIdentityLogSuppressionLock.synchronized { suppressionCount }
+
   /** Normalize an env-var value: trim surrounding whitespace and return
     * `Some(trimmed)` when the result is non-empty; `None` for absent, empty,
     * or whitespace-only values. Extracted as a pure helper so the trim+filter

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -43,27 +43,79 @@ import com.azure.identity.{
 object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
+  // NOTE on the package-private modifier used throughout this file:
+  // `private[chungmin]` (not `private[sbt]`) is deliberate. The plugin's
+  // package is `dev.chungmin.sbt`, so Scala's enclosing-package resolution
+  // for `private[X]` matches the leaf segment of that package — i.e.
+  // `private[sbt]` here would be `private[`dev.chungmin.sbt`]`, NOT
+  // package-private to the global `sbt` ecosystem (which is not an
+  // enclosing scope). `private[chungmin]` resolves unambiguously to
+  // `dev.chungmin.*` — a strictly clearer way to express "visible to test
+  // code in this package but not part of the user-facing API" without the
+  // parse hazard of looking exposed to all of sbt.
+
   /** Azure DevOps resource scope for access tokens. */
-  private[sbt] val AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default"
+  private[chungmin] val AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 
   /** System property to control Azure Identity SDK logging.
     * Set to "off" during token acquisition to suppress expected [ERROR] messages
     * from ChainedTokenCredential trying each provider in sequence. */
   private val AzureIdentityLogProperty = "org.slf4j.simpleLogger.log.com.azure.identity"
 
-  // Reference-counted suppression of the Azure-identity log-level system property.
-  // The first acquirer saves the previous value and sets the property to "off"; the
-  // last releaser restores it. Counted-set pattern so that multiple in-flight
-  // CredentialsBuilder instances share one suppression window without holding any
-  // lock during the (slow) Azure SDK call — only the brief save+set / restore
-  // boundaries serialize. Synchronized on this private monitor, not on the plugin
-  // object itself, so the lock can't be observed (or coincidentally taken) by
-  // outside code.
+  /** Set [[AzureIdentityLogProperty]] to `"off"` at plugin classloading if it
+    * isn't already set. Defends against the SLF4J SimpleLogger caching
+    * pattern: SimpleLogger reads the per-logger level once at logger
+    * instantiation time and caches it for the JVM's life. A later
+    * `System.setProperty(prop, "off")` only affects loggers that haven't
+    * been initialized yet; loggers already cached at INFO stay at INFO
+    * regardless. If anything else in the JVM (another sbt plugin pulling
+    * in azure-* transitively, an sbt server pre-classloading dependencies,
+    * a `console` invocation, a `Class.forName` in some diagnostic helper)
+    * touches a `com.azure.identity` logger BEFORE the plugin's first
+    * `getTokenImpl()` call, the per-call counted-set suppression becomes a
+    * silent no-op for the rest of the run.
+    *
+    * Running this in the plugin object's static-init block makes the
+    * suppression effective for the typical case "plugin classloads before
+    * azure-identity" — which holds in sbt because the AutoPlugin discovery
+    * generally precedes any user setting that touches azure-* directly.
+    * The case "azure-identity classloads before the plugin" (e.g. an
+    * upstream plugin already runs an `az` call from a setting) is
+    * unfixable from inside the plugin; the user should set
+    * `-Dorg.slf4j.simpleLogger.log.com.azure.identity=off` via JVM args.
+    *
+    * Respects a pre-existing user value so a developer who explicitly sets
+    * the property to `"debug"` for diagnostics sees their override. */
+  private[chungmin] def initializeAzureIdentityLogSuppression(): Unit = {
+    if (System.getProperty(AzureIdentityLogProperty) == null) {
+      System.setProperty(AzureIdentityLogProperty, "off")
+    }
+  }
+
+  initializeAzureIdentityLogSuppression()
+
+  // Reference-counted suppression of the Azure-identity log-level system
+  // property. The first acquirer saves the previous value and sets the
+  // property to "off"; the last releaser restores it. Counted-set pattern
+  // so that multiple in-flight CredentialsBuilder instances share one
+  // suppression window without holding any lock during the (slow) Azure
+  // SDK call — only the brief save+set / restore boundaries serialize.
+  //
+  // Synchronized on this private monitor, not on the plugin object itself,
+  // so the lock can't be observed (or coincidentally taken) by outside
+  // code.
+  //
+  // Important contract: the counted-set only flips the PROPERTY VALUE.
+  // SimpleLogger caches the level at logger init, so this is only fully
+  // effective if no com.azure.identity logger has been initialized yet
+  // when the first acquire runs. The static initializer above
+  // ([[initializeAzureIdentityLogSuppression]]) makes that precondition
+  // hold in the typical case (plugin classloads before azure-identity).
   private val AzureIdentityLogSuppressionLock = new Object
   private var suppressionCount: Int = 0
   private var savedAzureIdentityLogLevel: Option[String] = None
 
-  private[sbt] def acquireAzureIdentityLogSuppression(): Unit =
+  private[chungmin] def acquireAzureIdentityLogSuppression(): Unit =
     AzureIdentityLogSuppressionLock.synchronized {
       if (suppressionCount == 0) {
         savedAzureIdentityLogLevel = Option(System.getProperty(AzureIdentityLogProperty))
@@ -72,8 +124,18 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       suppressionCount += 1
     }
 
-  private[sbt] def releaseAzureIdentityLogSuppression(): Unit =
+  private[chungmin] def releaseAzureIdentityLogSuppression(): Unit =
     AzureIdentityLogSuppressionLock.synchronized {
+      // Fail fast at the actual bad caller: an unmatched release would
+      // drop the counter to -1, and the next acquire would see
+      // suppressionCount == 0 is false (it's -1) and skip the save+set,
+      // silently disabling the suppression for the rest of the JVM run.
+      // The drift looks healthy from the outside (count returns to 0
+      // again after one more acquire/release pair), so without this
+      // require() it'd go undetected in production.
+      require(
+        suppressionCount > 0,
+        "releaseAzureIdentityLogSuppression called without a matching acquire")
       suppressionCount -= 1
       if (suppressionCount == 0) {
         savedAzureIdentityLogLevel match {
@@ -91,9 +153,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * that leaks an unmatched acquire would otherwise manifest as a confusing
     * failure in a downstream test — the symptom (a wrong property value)
     * surfaces several tests away from the leak source. Exposed as
-    * `private[sbt]` so test code can assert `count == 0` between tests and
-    * pin any future leak to its actual source. */
-  private[sbt] def suppressionCountForTesting: Int =
+    * `private[chungmin]` so test code can assert `count == 0` between tests
+    * and pin any future leak to its actual source. */
+  private[chungmin] def suppressionCountForTesting: Int =
     AzureIdentityLogSuppressionLock.synchronized { suppressionCount }
 
   /** Normalize an env-var value: trim surrounding whitespace and return
@@ -102,53 +164,70 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * behavior is directly unit-testable (verifying via [[createCredential]]
     * alone would be tautological — the SDK builder accepts padded values, so
     * a chain-assembly assertion doesn't prove the trim ran). */
-  private[sbt] def envValue(env: Map[String, String], key: String): Option[String] =
+  private[chungmin] def envValue(env: Map[String, String], key: String): Option[String] =
     env.get(key).map(_.trim).filter(_.nonEmpty)
 
-  /** Create a credential chain that prioritizes user credentials over managed identity.
-    * Order: AzureCli → AzurePowerShell → Environment → WorkloadIdentity → ManagedIdentity.
-    * This ensures user's az login or Azure PowerShell session is preferred over VM identity.
+  /** Build the ordered list of credential providers that make up the
+    * Azure DevOps token chain. Order: AzureCli → AzurePowerShell →
+    * Environment → WorkloadIdentity (when its env vars are present) →
+    * ManagedIdentity. AzureCli first is the v0.0.8 motivation — on dev
+    * workstations with both `az login` and an ambient ManagedIdentity
+    * (e.g. inside an Azure VM), the user's `az login` session should win.
     *
-    * WorkloadIdentityCredentialBuilder.build() validates eagerly and throws
-    * IllegalArgumentException unless its clientId / tenantId / tokenFilePath are
-    * all set to non-null AND non-empty values. Unlike DefaultAzureCredential,
-    * it does NOT auto-read AZURE_CLIENT_ID / AZURE_TENANT_ID /
-    * AZURE_FEDERATED_TOKEN_FILE from the environment, so we populate them
-    * ourselves via [[envValue]]. When those env vars are absent, empty, or
-    * whitespace-only (the common case on dev workstations) we skip the
-    * credential entirely; otherwise the chain assembly would fail before
-    * AzureCli is ever tried. Padded values (e.g. a trailing newline from a
-    * broken env-template substitution) are trimmed before reaching the SDK,
-    * since the SDK accepts them at build time but they'd fail at getToken
-    * time and add noise to the chain.
+    * Exposed for testability so the chain *order* is directly assertable;
+    * [[ChainedTokenCredential]] doesn't expose its provider list, so a
+    * test on [[createCredential]]'s return value alone could only verify
+    * "the chain doesn't throw", not "AzureCli runs first" — which is the
+    * actual invariant the v0.0.8 fix relies on.
     *
-    * The env parameter exists for testability — production callers should use
-    * the default. */
-  private[sbt] def createCredential(env: Map[String, String] = sys.env): TokenCredential = {
-    val builder = new ChainedTokenCredentialBuilder()
-      .addLast(new AzureCliCredentialBuilder().build())
-      .addLast(new AzurePowerShellCredentialBuilder().build())
-      .addLast(new EnvironmentCredentialBuilder().build())
+    * WorkloadIdentityCredentialBuilder.build() validates eagerly and
+    * throws IllegalArgumentException unless its clientId / tenantId /
+    * tokenFilePath are all set to non-null AND non-empty values. Unlike
+    * DefaultAzureCredential, it does NOT auto-read AZURE_CLIENT_ID /
+    * AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE from the environment,
+    * so we populate them ourselves via [[envValue]]. When those env vars
+    * are absent, empty, or whitespace-only (the common case on dev
+    * workstations) we skip the credential entirely; otherwise the chain
+    * assembly would fail before AzureCli is ever tried. Padded values
+    * (e.g. a trailing newline from a broken env-template substitution)
+    * are trimmed by [[envValue]] before reaching the SDK, since the SDK
+    * accepts them at build time but they'd fail at getToken time and add
+    * noise to the chain.
+    *
+    * The env parameter exists for testability — production callers should
+    * use the default. */
+  private[chungmin] def credentialProviders(
+      env: Map[String, String] = sys.env): Seq[TokenCredential] = {
+    val providers = scala.collection.mutable.ListBuffer.empty[TokenCredential]
+    providers += new AzureCliCredentialBuilder().build()
+    providers += new AzurePowerShellCredentialBuilder().build()
+    providers += new EnvironmentCredentialBuilder().build()
     for {
       clientId  <- envValue(env, "AZURE_CLIENT_ID")
       tenantId  <- envValue(env, "AZURE_TENANT_ID")
       tokenFile <- envValue(env, "AZURE_FEDERATED_TOKEN_FILE")
     } {
-      builder.addLast(
-        new WorkloadIdentityCredentialBuilder()
-          .clientId(clientId)
-          .tenantId(tenantId)
-          .tokenFilePath(tokenFile)
-          .build()
-      )
+      providers += new WorkloadIdentityCredentialBuilder()
+        .clientId(clientId)
+        .tenantId(tenantId)
+        .tokenFilePath(tokenFile)
+        .build()
     }
-    builder
-      .addLast(new ManagedIdentityCredentialBuilder().build())
-      .build()
+    providers += new ManagedIdentityCredentialBuilder().build()
+    providers.toList
+  }
+
+  /** Create the [[ChainedTokenCredential]] used at token-acquisition time.
+    * Thin wrapper over [[credentialProviders]] that wires the seq into a
+    * [[ChainedTokenCredentialBuilder]]. */
+  private[chungmin] def createCredential(env: Map[String, String] = sys.env): TokenCredential = {
+    val builder = new ChainedTokenCredentialBuilder()
+    credentialProviders(env).foreach(builder.addLast)
+    builder.build()
   }
 
   /** Extract organization name from Azure DevOps URL. Exposed for testing. */
-  private[sbt] def getOrganization(uri: URI): Option[String] = {
+  private[chungmin] def getOrganization(uri: URI): Option[String] = {
     val host = uri.getHost
     if (host == null) {
       None
@@ -164,7 +243,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   }
 
   /** Check if host is an Azure DevOps package feed. Exposed for testing. */
-  private[sbt] def isAzureDevOpsHost(host: String): Boolean = {
+  private[chungmin] def isAzureDevOpsHost(host: String): Boolean = {
     host != null && (host.endsWith("pkgs.visualstudio.com") || host == "pkgs.dev.azure.com")
   }
 
@@ -173,7 +252,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * exercising it through [[headRequestHeaders]] would require an actual socket
     * round-trip and only verifies behavior tautologically (any port choice fails
     * the same way against an unresponsive address). */
-  private[sbt] def defaultPort(uri: URI): Int =
+  private[chungmin] def defaultPort(uri: URI): Int =
     if (uri.getPort >= 0) uri.getPort
     else if (uri.getScheme == "https") 443
     else 80
@@ -183,7 +262,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * Uses a raw socket instead of HttpURLConnection to avoid triggering
     * sbt's global IvyAuthenticator, which logs spurious "Unable to find
     * credentials" error messages when the server responds with 401. */
-  private[sbt] def headRequestHeaders(uri: URI): Seq[(String, String)] = {
+  private[chungmin] def headRequestHeaders(uri: URI): Seq[(String, String)] = {
     val host = uri.getHost
     val port = defaultPort(uri)
     val path = Option(uri.getRawPath).filter(_.nonEmpty).getOrElse("/")
@@ -398,7 +477,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   }
 
   // Fix for https://github.com/coursier/coursier/issues/1649
-  private[sbt] def updateCoursierConf(
+  private[chungmin] def updateCoursierConf(
       conf: CoursierConfiguration,
       resolvers: Seq[Resolver],
       credentials: Seq[Credentials]) = {

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -177,73 +177,28 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     // AzureCli was ever tried — leaving developer workstations (which don't
     // normally have those env vars set) with a plugin that always reported
     // "failed to get access token. Did you forget to run `az login`?".
+    //
+    // The `credentialProviders` tests below pin the *order* invariant
+    // directly (which a `cred should not be null` assertion can't), and
+    // `envValue`'s direct unit tests cover the absent / empty / whitespace /
+    // padded states — so this one test is sufficient as a named regression
+    // anchor for the v0.0.8 repro.
     val cred = AzureDevOpsCredentialsPlugin.createCredential(Map.empty)
     cred should not be null
   }
 
-  it should "build a chain without throwing when workload-identity env vars are set" in {
-    val env = Map(
-      "AZURE_CLIENT_ID" -> "00000000-0000-0000-0000-000000000000",
-      "AZURE_TENANT_ID" -> "00000000-0000-0000-0000-000000000000",
-      "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
-    )
-    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
-    cred should not be null
-  }
-
-  it should "build a chain without throwing when AAD env vars are present but empty" in {
-    // The Azure SDK's WorkloadIdentityCredentialBuilder.build() rejects both
-    // null AND empty strings — `env.get("AZURE_CLIENT_ID")` returning Some("")
-    // would re-trigger the same eager IllegalArgumentException that broke
-    // v0.0.8, just by a different code path. Some CI images, partially-
-    // configured shells, and k8s service-account projection edge cases can
-    // export env vars as empty strings, so this case needs the same
-    // skip-the-credential treatment as "var entirely absent".
-    val env = Map(
-      "AZURE_CLIENT_ID" -> "",
-      "AZURE_TENANT_ID" -> "",
-      "AZURE_FEDERATED_TOKEN_FILE" -> ""
-    )
-    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
-    cred should not be null
-  }
-
-  it should "build a chain without throwing when only some AAD env vars are empty" in {
-    // Mixed case: AZURE_CLIENT_ID is empty but the other two are set. Without
-    // the per-value .filter(_.trim.nonEmpty), the for-comprehension would still
-    // succeed (Some("") satisfies the comprehension) and the builder's
-    // .clientId("") + .build() would throw.
-    val env = Map(
-      "AZURE_CLIENT_ID" -> "",
-      "AZURE_TENANT_ID" -> "00000000-0000-0000-0000-000000000000",
-      "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
-    )
-    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
-    cred should not be null
-  }
-
-  it should "build a chain without throwing when AAD env vars are whitespace-only" in {
-    // The Azure SDK's `Strings.isNullOrEmpty` only checks null + empty; whitespace-
-    // only values like "  " or "\t" pass validation and end up in the credential
-    // as garbage. `.trim.nonEmpty` (instead of just `.nonEmpty`) skips them, which
-    // is defense-in-depth against a partially-broken env-template substitution.
-    val env = Map(
-      "AZURE_CLIENT_ID" -> "  ",
-      "AZURE_TENANT_ID" -> "\t",
-      "AZURE_FEDERATED_TOKEN_FILE" -> "   \n"
-    )
-    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
-    cred should not be null
-  }
-
   it should "build a chain without throwing when AAD env vars are padded with whitespace" in {
-    // Continuation of the whitespace defense above: a partially-broken
+    // End-to-end smoke test for the trim defense: a partially-broken
     // env-template substitution may produce a *padded* value (e.g. trailing
     // newline from a YAML literal block) rather than a pure-whitespace one.
-    // The SDK builder accepts padded values at .build() time, so this test
-    // doesn't tautologically verify the trim — that's what `envValue`'s
-    // direct unit tests are for. This is a smoke test that the chain
-    // assembly path tolerates padded values.
+    // The SDK builder accepts padded values at .build() time and would only
+    // fail at .getToken() time with a confusing AAD error.
+    //
+    // Required because a `credentialProviders` order assertion against the
+    // padded env can't prove the trim ran — the chain-element classes are
+    // the same regardless of whether the credential was built with padded
+    // or trimmed values. This test verifies the end-to-end path:
+    // createCredential → credentialProviders → for-yield → envValue.trim.
     val env = Map(
       "AZURE_CLIENT_ID" -> "  00000000-0000-0000-0000-000000000000  ",
       "AZURE_TENANT_ID" -> "\t00000000-0000-0000-0000-000000000000\n",
@@ -311,7 +266,7 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     // Direct exercise of the static-init helper. The block runs once at
     // plugin classloading; re-invoking it from a test (with the property
     // explicitly cleared first) verifies the unset->"off" path.
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     System.clearProperty(prop)
     try {
@@ -329,7 +284,7 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     // A developer who sets the property explicitly (e.g. -Dorg.slf4j.simpleLogger.log.com.azure.identity=debug
     // for diagnostics) should see their override survive plugin classloading.
     // Verifies the "no-op when set" branch of the static-init helper.
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     System.setProperty(prop, "debug")
     try {

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -253,6 +253,44 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     cred should not be null
   }
 
+  "credentialProviders" should "place AzureCli first and ManagedIdentity last when AAD env vars are unset" in {
+    // Pins the v0.0.8 chain order: on dev workstations with no AAD env vars,
+    // AzureCli must be tried first (the v0.0.8 motivation), and ManagedIdentity
+    // must be the fallback for VM-resident builds. A future refactor that
+    // swaps the .addLast calls would still pass every other regression test
+    // because they all assert on "chain assembly doesn't throw" rather than
+    // on provider ordering — but it would silently regress the original bug
+    // (user's `az login` ignored in favor of the VM's managed identity).
+    val providers = AzureDevOpsCredentialsPlugin.credentialProviders(Map.empty)
+    providers.map(_.getClass.getSimpleName) shouldBe Seq(
+      "AzureCliCredential",
+      "AzurePowerShellCredential",
+      "EnvironmentCredential",
+      "ManagedIdentityCredential"
+    )
+  }
+
+  it should "insert WorkloadIdentity between EnvironmentCredential and ManagedIdentity when AAD env vars are set" in {
+    // Position-sensitive: WorkloadIdentity should run AFTER user-credential
+    // providers (AzureCli / PowerShell / Environment) so an interactive
+    // developer session wins over a partially-configured workload-identity
+    // setup, but BEFORE ManagedIdentity so a k8s pod with workload-identity
+    // env vars set doesn't fall through to a VM managed identity.
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "00000000-0000-0000-0000-000000000000",
+      "AZURE_TENANT_ID" -> "11111111-1111-1111-1111-111111111111",
+      "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
+    )
+    val providers = AzureDevOpsCredentialsPlugin.credentialProviders(env)
+    providers.map(_.getClass.getSimpleName) shouldBe Seq(
+      "AzureCliCredential",
+      "AzurePowerShellCredential",
+      "EnvironmentCredential",
+      "WorkloadIdentityCredential",
+      "ManagedIdentityCredential"
+    )
+  }
+
   "envValue" should "return Some(trimmed) for padded values" in {
     val env = Map("X" -> "  abc  ", "Y" -> "\tabc\n", "Z" -> "abc")
     AzureDevOpsCredentialsPlugin.envValue(env, "X") shouldBe Some("abc")
@@ -267,5 +305,41 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     AzureDevOpsCredentialsPlugin.envValue(env, "tabs") shouldBe None
     AzureDevOpsCredentialsPlugin.envValue(env, "mixed") shouldBe None
     AzureDevOpsCredentialsPlugin.envValue(env, "missing") shouldBe None
+  }
+
+  "initializeAzureIdentityLogSuppression" should "set the property to 'off' when unset" in {
+    // Direct exercise of the static-init helper. The block runs once at
+    // plugin classloading; re-invoking it from a test (with the property
+    // explicitly cleared first) verifies the unset->"off" path.
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    System.clearProperty(prop)
+    try {
+      AzureDevOpsCredentialsPlugin.initializeAzureIdentityLogSuppression()
+      System.getProperty(prop) shouldBe "off"
+    } finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
+  }
+
+  it should "not override a pre-existing value" in {
+    // A developer who sets the property explicitly (e.g. -Dorg.slf4j.simpleLogger.log.com.azure.identity=debug
+    // for diagnostics) should see their override survive plugin classloading.
+    // Verifies the "no-op when set" branch of the static-init helper.
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    System.setProperty(prop, "debug")
+    try {
+      AzureDevOpsCredentialsPlugin.initializeAzureIdentityLogSuppression()
+      System.getProperty(prop) shouldBe "debug"
+    } finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
   }
 }

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -168,4 +168,26 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
       server.close()
     }
   }
+
+  "createCredential" should "build a chain without throwing when no AAD env vars are set" in {
+    // Regression test for v0.0.8: WorkloadIdentityCredentialBuilder.build()
+    // throws IllegalArgumentException when AZURE_CLIENT_ID / AZURE_TENANT_ID /
+    // AZURE_FEDERATED_TOKEN_FILE are unset. Because that .build() is called
+    // eagerly during chain assembly, the entire chain construction failed before
+    // AzureCli was ever tried — leaving developer workstations (which don't
+    // normally have those env vars set) with a plugin that always reported
+    // "failed to get access token. Did you forget to run `az login`?".
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(Map.empty)
+    cred should not be null
+  }
+
+  it should "build a chain without throwing when workload-identity env vars are set" in {
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "00000000-0000-0000-0000-000000000000",
+      "AZURE_TENANT_ID" -> "00000000-0000-0000-0000-000000000000",
+      "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
+    )
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
+    cred should not be null
+  }
 }

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -235,4 +235,37 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
     cred should not be null
   }
+
+  it should "build a chain without throwing when AAD env vars are padded with whitespace" in {
+    // Continuation of the whitespace defense above: a partially-broken
+    // env-template substitution may produce a *padded* value (e.g. trailing
+    // newline from a YAML literal block) rather than a pure-whitespace one.
+    // The SDK builder accepts padded values at .build() time, so this test
+    // doesn't tautologically verify the trim — that's what `envValue`'s
+    // direct unit tests are for. This is a smoke test that the chain
+    // assembly path tolerates padded values.
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "  00000000-0000-0000-0000-000000000000  ",
+      "AZURE_TENANT_ID" -> "\t00000000-0000-0000-0000-000000000000\n",
+      "AZURE_FEDERATED_TOKEN_FILE" -> "  /tmp/nonexistent-federated-token  "
+    )
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
+    cred should not be null
+  }
+
+  "envValue" should "return Some(trimmed) for padded values" in {
+    val env = Map("X" -> "  abc  ", "Y" -> "\tabc\n", "Z" -> "abc")
+    AzureDevOpsCredentialsPlugin.envValue(env, "X") shouldBe Some("abc")
+    AzureDevOpsCredentialsPlugin.envValue(env, "Y") shouldBe Some("abc")
+    AzureDevOpsCredentialsPlugin.envValue(env, "Z") shouldBe Some("abc")
+  }
+
+  it should "return None for absent, empty, or whitespace-only values" in {
+    val env = Map("empty" -> "", "spaces" -> "   ", "tabs" -> "\t\t", "mixed" -> "  \n\t  ")
+    AzureDevOpsCredentialsPlugin.envValue(env, "empty") shouldBe None
+    AzureDevOpsCredentialsPlugin.envValue(env, "spaces") shouldBe None
+    AzureDevOpsCredentialsPlugin.envValue(env, "tabs") shouldBe None
+    AzureDevOpsCredentialsPlugin.envValue(env, "mixed") shouldBe None
+    AzureDevOpsCredentialsPlugin.envValue(env, "missing") shouldBe None
+  }
 }

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -210,13 +210,27 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
 
   it should "build a chain without throwing when only some AAD env vars are empty" in {
     // Mixed case: AZURE_CLIENT_ID is empty but the other two are set. Without
-    // the per-value .filter(_.nonEmpty), the for-comprehension would still
+    // the per-value .filter(_.trim.nonEmpty), the for-comprehension would still
     // succeed (Some("") satisfies the comprehension) and the builder's
     // .clientId("") + .build() would throw.
     val env = Map(
       "AZURE_CLIENT_ID" -> "",
       "AZURE_TENANT_ID" -> "00000000-0000-0000-0000-000000000000",
       "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
+    )
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
+    cred should not be null
+  }
+
+  it should "build a chain without throwing when AAD env vars are whitespace-only" in {
+    // The Azure SDK's `Strings.isNullOrEmpty` only checks null + empty; whitespace-
+    // only values like "  " or "\t" pass validation and end up in the credential
+    // as garbage. `.trim.nonEmpty` (instead of just `.nonEmpty`) skips them, which
+    // is defense-in-depth against a partially-broken env-template substitution.
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "  ",
+      "AZURE_TENANT_ID" -> "\t",
+      "AZURE_FEDERATED_TOKEN_FILE" -> "   \n"
     )
     val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
     cred should not be null

--- a/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPluginSpec.scala
@@ -190,4 +190,35 @@ class AzureDevOpsCredentialsPluginSpec extends AnyFlatSpec with Matchers {
     val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
     cred should not be null
   }
+
+  it should "build a chain without throwing when AAD env vars are present but empty" in {
+    // The Azure SDK's WorkloadIdentityCredentialBuilder.build() rejects both
+    // null AND empty strings — `env.get("AZURE_CLIENT_ID")` returning Some("")
+    // would re-trigger the same eager IllegalArgumentException that broke
+    // v0.0.8, just by a different code path. Some CI images, partially-
+    // configured shells, and k8s service-account projection edge cases can
+    // export env vars as empty strings, so this case needs the same
+    // skip-the-credential treatment as "var entirely absent".
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "",
+      "AZURE_TENANT_ID" -> "",
+      "AZURE_FEDERATED_TOKEN_FILE" -> ""
+    )
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
+    cred should not be null
+  }
+
+  it should "build a chain without throwing when only some AAD env vars are empty" in {
+    // Mixed case: AZURE_CLIENT_ID is empty but the other two are set. Without
+    // the per-value .filter(_.nonEmpty), the for-comprehension would still
+    // succeed (Some("") satisfies the comprehension) and the builder's
+    // .clientId("") + .build() would throw.
+    val env = Map(
+      "AZURE_CLIENT_ID" -> "",
+      "AZURE_TENANT_ID" -> "00000000-0000-0000-0000-000000000000",
+      "AZURE_FEDERATED_TOKEN_FILE" -> "/tmp/nonexistent-federated-token"
+    )
+    val cred = AzureDevOpsCredentialsPlugin.createCredential(env)
+    cred should not be null
+  }
 }

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -632,9 +632,14 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     AzureDevOpsCredentialsPlugin.defaultPort(new URI("https://example.com/")) shouldBe 443
   }
 
-  it should "default to 80 for non-https schemes with no explicit port" in {
-    // The branch is "https -> 443 else 80"; assert the else path on a non-https,
-    // non-http scheme (e.g. ftp) actually returns 80, not 443.
+  it should "fall through to 80 for non-http(s) schemes (gate-coverage tail, not a canonical default)" in {
+    // Pins the `else 80` branch in defaultPort. No real call site passes a
+    // non-http(s) URI here — headRequestHeaders is fed MavenRepo URIs that
+    // isAzureDevOpsHost has already filtered to http/https — but the
+    // 100% coverage gate requires the else branch be exercised. Using
+    // ftp:// (canonical port 21) intentionally: the assertion `shouldBe 80`
+    // (NOT `shouldBe 21`) documents that this is a fallback, not a
+    // scheme-aware lookup.
     AzureDevOpsCredentialsPlugin.defaultPort(new URI("ftp://example.com/")) shouldBe 80
   }
 }

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -368,7 +368,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   }
 
   it should "restore the previous Azure-identity log level after token acquisition" in {
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     try {
       System.setProperty(prop, "debug")
@@ -383,7 +383,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   }
 
   it should "clear the Azure-identity log level when none was set before" in {
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     System.clearProperty(prop)
     try {
@@ -416,7 +416,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     // 8-thread variant verifies the live integration path through
     // getTokenImpl; the nested-suppression test verifies the counted-set
     // helpers directly.
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     System.setProperty(prop, "initial")
     try {
@@ -449,7 +449,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     // Directly exercises the counted-set helpers to assert the invariant the
     // 8-thread concurrency test relies on: inner acquire/release does NOT
     // restore the property while an outer suppression is still in flight.
-    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val prop = AzureDevOpsCredentialsPlugin.AzureIdentityLogProperty
     val original = Option(System.getProperty(prop))
     System.setProperty(prop, "initial")
     try {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -513,20 +513,24 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "default to port 80 for http URIs with no explicit port" in {
-    // Hit a TCP server we just started, but address it via a URI that has no
-    // explicit port. We can't bind port 80 in CI, so instead we use 127.0.0.2
-    // (a localhost alias that is guaranteed unreachable) — the connect attempt
-    // exercises the "scheme == http, no port -> 80" branch even though the
-    // actual TCP connect fails.
-    val uri = new URI("http://127.0.0.2/")
-    // Either the connect times out or it's refused; either way the function
-    // throws, which is what we want to assert.
-    an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+  // ─── defaultPort (pure helper — no socket) ──────────────────────────────
+
+  "defaultPort" should "return the explicit port when set" in {
+    AzureDevOpsCredentialsPlugin.defaultPort(new URI("http://example.com:8080/")) shouldBe 8080
+    AzureDevOpsCredentialsPlugin.defaultPort(new URI("https://example.com:8443/")) shouldBe 8443
   }
 
-  it should "default to port 443 for https URIs with no explicit port" in {
-    val uri = new URI("https://127.0.0.2/")
-    an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+  it should "default to 80 for http URIs with no explicit port" in {
+    AzureDevOpsCredentialsPlugin.defaultPort(new URI("http://example.com/")) shouldBe 80
+  }
+
+  it should "default to 443 for https URIs with no explicit port" in {
+    AzureDevOpsCredentialsPlugin.defaultPort(new URI("https://example.com/")) shouldBe 443
+  }
+
+  it should "default to 80 for non-https schemes with no explicit port" in {
+    // The branch is "https -> 443 else 80"; assert the else path on a non-https,
+    // non-http scheme (e.g. ftp) actually returns 80, not 443.
+    AzureDevOpsCredentialsPlugin.defaultPort(new URI("ftp://example.com/")) shouldBe 80
   }
 }

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -19,6 +19,7 @@ import java.io.{BufferedWriter, File, OutputStreamWriter, PrintWriter}
 import java.net.{ServerSocket, URI}
 import java.nio.file.Files
 import java.time.OffsetDateTime
+import javax.net.ssl.SSLException
 
 import scala.util.control.NonFatal
 
@@ -361,9 +362,9 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "restore the Azure-identity log level when concurrent CredentialsBuilder instances acquire tokens" in {
-    // Regression guard for the save/set/restore race: without a JVM-wide lock,
-    // two builders could observe each other's "off" mutation and leave the
-    // property pinned to "off" after both threads finish.
+    // Regression guard for the save/set/restore race: without a JVM-wide
+    // counted-set, two builders could observe each other's "off" mutation and
+    // leave the property pinned to "off" after both threads finish.
     val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
     val original = Option(System.getProperty(prop))
     System.setProperty(prop, "initial")
@@ -378,6 +379,32 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
         t
       }
       threads.foreach(_.join())
+      System.getProperty(prop) shouldBe "initial"
+    } finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
+  }
+
+  it should "keep the Azure-identity log level pinned to 'off' across nested suppressions and only restore on the outermost release" in {
+    // Directly exercises the counted-set helpers to assert the invariant the
+    // 8-thread concurrency test relies on: inner acquire/release does NOT
+    // restore the property while an outer suppression is still in flight.
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    System.setProperty(prop, "initial")
+    try {
+      AzureDevOpsCredentialsPlugin.acquireAzureIdentityLogSuppression()
+      System.getProperty(prop) shouldBe "off"
+      AzureDevOpsCredentialsPlugin.acquireAzureIdentityLogSuppression()
+      System.getProperty(prop) shouldBe "off"
+      AzureDevOpsCredentialsPlugin.releaseAzureIdentityLogSuppression()
+      // Inner release: still suppressed because outer is still in flight.
+      System.getProperty(prop) shouldBe "off"
+      AzureDevOpsCredentialsPlugin.releaseAzureIdentityLogSuppression()
+      // Outer release: property restored to the saved-at-first-acquire value.
       System.getProperty(prop) shouldBe "initial"
     } finally {
       original match {
@@ -502,14 +529,16 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "wrap the socket with SSLSocketFactory when the scheme is https" in {
-    // Point an https URI at a plain-HTTP test server. The TLS handshake will
-    // fail (the server is speaking HTTP/1.1), but the wrap-with-SSL path on
-    // line ~128 still runs. The plugin propagates the error to getRealm which
-    // converts it to None — but here we just assert headRequestHeaders throws,
-    // which proves we entered the SSL wrap branch.
+    // Point an https URI at a plain-HTTP test server. The TLS handshake fails
+    // because the server immediately writes "HTTP/1.1 200 OK\r\n\r\n" — not a
+    // valid TLS record. Assert specifically on SSLException (rather than the
+    // broader `Exception`) so a future refactor that drops the SSLSocketFactory
+    // wrap entirely would surface as the test catching a non-SSL exception
+    // (e.g. parse failure on the plain HTTP response) instead of silently
+    // passing on whatever generic throwable happened.
     withRawHeadServer("HTTP/1.1 200 OK\r\n\r\n") { (host, port) =>
       val uri = new URI(s"https://$host:$port/")
-      an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+      an[SSLException] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
     }
   }
 

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -18,7 +18,8 @@ package dev.chungmin.sbt
 import java.io.{BufferedWriter, File, OutputStreamWriter, PrintWriter}
 import java.net.{ServerSocket, URI}
 import java.nio.file.Files
-import java.time.OffsetDateTime
+import java.time.{Duration, OffsetDateTime}
+import java.util.concurrent.CountDownLatch
 import javax.net.ssl.SSLException
 
 import scala.util.control.NonFatal
@@ -334,6 +335,27 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
     calls shouldBe 1
   }
 
+  it should "cache the None result and not re-try on subsequent calls" in {
+    // Companion to the Some-caching test above: `cachedToken` is
+    // Option[Option[String]] precisely to distinguish "not yet attempted"
+    // from "attempted, no token". Without this assertion, a future refactor
+    // to Option[String] semantics (treating None as "not yet attempted")
+    // would silently re-trigger the full chain on every resolver in a
+    // misconfigured sbt build — exactly what the cache exists to prevent.
+    var calls = 0
+    val probe = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      override protected def newCredential(): TokenCredential = {
+        calls += 1
+        fakeCredential(Mono.error[AccessToken](new RuntimeException("boom")))
+      }
+      def fetch(): Option[String] = getToken()
+    }
+    probe.fetch() shouldBe None
+    probe.fetch() shouldBe None
+    probe.fetch() shouldBe None
+    calls shouldBe 1
+  }
+
   it should "restore the previous Azure-identity log level after token acquisition" in {
     val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
     val original = Option(System.getProperty(prop))
@@ -365,19 +387,43 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
     // Regression guard for the save/set/restore race: without a JVM-wide
     // counted-set, two builders could observe each other's "off" mutation and
     // leave the property pinned to "off" after both threads finish.
+    //
+    // The pre-fix code synchronized only on the CredentialsBuilder instance,
+    // so concurrent instances' save/set/restore blocks could interleave.
+    // The race window is the time between save (read property as X) and
+    // restore (write property back to X). To actually exercise that window,
+    // (a) all 8 threads gate on a CountDownLatch so they enter the
+    // acquire/SDK/release path within nanoseconds of each other, and
+    // (b) the credential's Mono is delayed by 50ms so the per-thread
+    // critical section is long enough for the interleaving to happen.
+    // (`Mono.just(...)` would resolve in microseconds — shorter than the
+    // cost of starting the next Thread — and the threads would typically
+    // run sequentially, neutering the regression guard.)
+    //
+    // This is paired with the deterministic counted-set invariant test
+    // below ("keep ... pinned to 'off' across nested suppressions"). This
+    // 8-thread variant verifies the live integration path through
+    // getTokenImpl; the nested-suppression test verifies the counted-set
+    // helpers directly.
     val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
     val original = Option(System.getProperty(prop))
     System.setProperty(prop, "initial")
     try {
+      val barrier = new CountDownLatch(1)
       val threads = (1 to 8).map { i =>
         val t = new Thread(new Runnable {
           def run(): Unit = {
-            new TokenProbe(credentialReturning(s"tok-$i")).fetch()
+            val delayedCred = fakeCredential(
+              Mono.just(new AccessToken(s"tok-$i", OffsetDateTime.now().plusHours(1)))
+                .delayElement(Duration.ofMillis(50)))
+            barrier.await()
+            new TokenProbe(delayedCred).fetch()
           }
         })
         t.start()
         t
       }
+      barrier.countDown()
       threads.foreach(_.join())
       System.getProperty(prop) shouldBe "initial"
     } finally {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -360,6 +360,33 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "restore the Azure-identity log level when concurrent CredentialsBuilder instances acquire tokens" in {
+    // Regression guard for the save/set/restore race: without a JVM-wide lock,
+    // two builders could observe each other's "off" mutation and leave the
+    // property pinned to "off" after both threads finish.
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    System.setProperty(prop, "initial")
+    try {
+      val threads = (1 to 8).map { i =>
+        val t = new Thread(new Runnable {
+          def run(): Unit = {
+            new TokenProbe(credentialReturning(s"tok-$i")).fetch()
+          }
+        })
+        t.start()
+        t
+      }
+      threads.foreach(_.join())
+      System.getProperty(prop) shouldBe "initial"
+    } finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
+  }
+
   // ─── updateCoursierConf ─────────────────────────────────────────────────
 
   "updateCoursierConf" should "add authentication for MavenRepos with matching credentials" in {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -1,0 +1,505 @@
+// Copyright (C) 2024 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.chungmin.sbt
+
+import java.io.{BufferedWriter, File, OutputStreamWriter, PrintWriter}
+import java.net.{ServerSocket, URI}
+import java.nio.file.Files
+import java.time.OffsetDateTime
+
+import scala.util.control.NonFatal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import sbt._
+import sbt.util.Logger
+import lmcoursier.CoursierConfiguration
+import lmcoursier.definitions.Authentication
+import com.azure.core.credential.{AccessToken, TokenCredential, TokenRequestContext}
+import reactor.core.publisher.Mono
+
+class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
+
+  // ─── Test fixtures ─────────────────────────────────────────────────────
+
+  /** No-op logger so tests don't pollute stdout. Evaluates by-name message
+    * args (then discards them) so that scoverage sees the string-construction
+    * statements being executed; otherwise every log.debug(s"…") call would be
+    * counted as uncovered. */
+  private val nullLog: Logger = new Logger {
+    override def trace(t: => Throwable): Unit = { val _ = t }
+    override def success(message: => String): Unit = { val _ = message }
+    override def log(level: sbt.util.Level.Value, message: => String): Unit = { val _ = message }
+  }
+
+  /** Realistic ADO realm — exactly what `pkgs.dev.azure.com` returns in the
+    * `WWW-Authenticate: Basic realm="..."` header of its 401 responses. */
+  private val AdoRealm = "https://pkgsprodsu3weu.pkgs.visualstudio.com/"
+
+  private val AdoFeedUrl = "https://pkgs.dev.azure.com/myorg/myproject/_packaging/myfeed/maven/v1"
+  private val LegacyAdoFeedUrl = "https://myorg.pkgs.visualstudio.com/myproject/_packaging/myfeed/maven/v1"
+
+  /** Build a fake TokenCredential whose `getToken(...)` returns the given Mono. */
+  private def fakeCredential(mono: Mono[AccessToken]): TokenCredential =
+    new TokenCredential {
+      override def getToken(request: TokenRequestContext): Mono[AccessToken] = mono
+    }
+
+  /** Convenience: TokenCredential that returns a specific token string. */
+  private def credentialReturning(token: String): TokenCredential =
+    fakeCredential(Mono.just(new AccessToken(token, OffsetDateTime.now().plusHours(1))))
+
+  /** Construct a CredentialsBuilder with all external dependencies stubbed. */
+  private def testBuilder(
+      realm: URI => Option[String] = _ => Some(AdoRealm),
+      token: () => Option[String] = () => Some("test-pat"),
+      settings: File = new File("/this/path/does/not/exist")
+  ): AzureDevOpsCredentialsPlugin.CredentialsBuilder = {
+    new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      override protected def getRealm(uri: URI): Option[String] = realm(uri)
+      override protected def getToken(): Option[String] = token()
+      override protected def mavenSettingsFile: File = settings
+    }
+  }
+
+  /** Write a settings.xml to a temp file. */
+  private def writeSettings(content: String): File = {
+    val f = Files.createTempFile("settings-", ".xml").toFile
+    f.deleteOnExit()
+    val w = new PrintWriter(f, "UTF-8")
+    try w.write(content) finally w.close()
+    f
+  }
+
+  // ─── buildCredentials ───────────────────────────────────────────────────
+
+  "CredentialsBuilder.buildCredentials" should
+      "generate access-token credentials for a pkgs.dev.azure.com MavenRepo" in {
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val result = testBuilder().buildCredentials(Seq.empty, Seq(resolver))
+    result should have size 1
+    val cred = result.head.asInstanceOf[DirectCredentials]
+    cred.realm shouldBe AdoRealm
+    cred.host shouldBe "pkgs.dev.azure.com"
+    cred.userName shouldBe "myorg"
+    cred.passwd shouldBe "test-pat"
+  }
+
+  it should "generate access-token credentials for legacy *.pkgs.visualstudio.com feeds" in {
+    val resolver = MavenRepository("AzureDevOps", LegacyAdoFeedUrl)
+    val result = testBuilder().buildCredentials(Seq.empty, Seq(resolver))
+    result should have size 1
+    val cred = result.head.asInstanceOf[DirectCredentials]
+    cred.host shouldBe "myorg.pkgs.visualstudio.com"
+    cred.userName shouldBe "myorg"
+  }
+
+  it should "skip MavenRepos that aren't Azure DevOps" in {
+    val resolver = MavenRepository("Maven Central", "https://repo1.maven.org/maven2/")
+    testBuilder().buildCredentials(Seq.empty, Seq(resolver)) shouldBe empty
+  }
+
+  it should "skip when realm cannot be determined" in {
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    testBuilder(realm = _ => None).buildCredentials(Seq.empty, Seq(resolver)) shouldBe empty
+  }
+
+  it should "skip when token cannot be acquired" in {
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    testBuilder(token = () => None).buildCredentials(Seq.empty, Seq(resolver)) shouldBe empty
+  }
+
+  it should "skip when the host already has existing DirectCredentials" in {
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val existing = Credentials("preset-realm", "pkgs.dev.azure.com", "preset-user", "preset-pat")
+    testBuilder().buildCredentials(Seq(existing), Seq(resolver)) shouldBe empty
+  }
+
+  it should "ignore non-MavenRepo resolvers" in {
+    val resolver: Resolver = Resolver.file("local-ivy", new File("/tmp"))
+    testBuilder().buildCredentials(Seq.empty, Seq(resolver)) shouldBe empty
+  }
+
+  it should "process multiple resolvers independently" in {
+    val r1 = MavenRepository("Ado1", "https://pkgs.dev.azure.com/orgA/_packaging/feed/maven/v1")
+    val r2 = MavenRepository("Ado2", "https://pkgs.dev.azure.com/orgB/_packaging/feed/maven/v1")
+    val r3 = MavenRepository("Central", "https://repo1.maven.org/maven2/")
+    val result = testBuilder().buildCredentials(Seq.empty, Seq(r1, r2, r3))
+    val users = result.collect { case c: DirectCredentials => c.userName }
+    users should contain theSameElementsAs Seq("orgA", "orgB")
+  }
+
+  // ─── buildCredentialsFromMavenSettings (exercised via buildCredentials) ─
+
+  "buildCredentialsFromMavenSettings" should
+      "load credentials from settings.xml when <server id> matches resolver name" in {
+    val settings = writeSettings(
+      """<?xml version="1.0"?>
+        |<settings>
+        |  <servers>
+        |    <server>
+        |      <id>AzureDevOps</id>
+        |      <username>maven-user</username>
+        |      <password>maven-token</password>
+        |    </server>
+        |  </servers>
+        |</settings>""".stripMargin)
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(settings = settings)
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    // We get one settings-derived cred (maven-user) — the access-token path is
+    // skipped because the settings-derived cred already populates the host.
+    result should have size 1
+    val cred = result.head.asInstanceOf[DirectCredentials]
+    cred.realm shouldBe AdoRealm
+    cred.host shouldBe "pkgs.dev.azure.com"
+    cred.userName shouldBe "maven-user"
+    cred.passwd shouldBe "maven-token"
+  }
+
+  it should "return empty when the settings.xml file does not exist" in {
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(settings = new File("/no/such/settings.xml"))
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    // No settings creds; only the access-token cred.
+    val users = result.collect { case c: DirectCredentials => c.userName }
+    users shouldBe Seq("myorg")
+  }
+
+  it should "skip when no <server> matches the resolver name" in {
+    val settings = writeSettings(
+      """<settings>
+        |  <servers>
+        |    <server>
+        |      <id>SomeOtherRepo</id>
+        |      <username>u</username>
+        |      <password>p</password>
+        |    </server>
+        |  </servers>
+        |</settings>""".stripMargin)
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(settings = settings)
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    val settingsCreds = result.collect {
+      case c: DirectCredentials if c.userName == "u" => c
+    }
+    settingsCreds shouldBe empty
+  }
+
+  it should "skip a matching <server> when realm cannot be determined" in {
+    val settings = writeSettings(
+      """<settings>
+        |  <servers>
+        |    <server>
+        |      <id>AzureDevOps</id>
+        |      <username>u</username>
+        |      <password>p</password>
+        |    </server>
+        |  </servers>
+        |</settings>""".stripMargin)
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(settings = settings, realm = _ => None)
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    result shouldBe empty
+  }
+
+  // ─── getRealm (real implementation against local HTTP server) ───────────
+
+  /** Test subclass exposing the protected getRealm for direct testing.
+    *
+    * The behaviour mirrors a real Azure DevOps Maven feed: when an
+    * unauthenticated client hits the feed root, ADO returns 401 with a
+    * `WWW-Authenticate: Basic realm="..."` header (along with Bearer +
+    * TFS-Federated challenges, which the plugin must skip past). */
+  private class RealmProbe extends AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+    def probe(uri: URI): Option[String] = getRealm(uri)
+  }
+
+  private def withHttpServer(rawResponse: String)(test: URI => Unit): Unit = {
+    val server = new ServerSocket(0)
+    try {
+      val t = new Thread(() => {
+        try {
+          val client = server.accept()
+          try {
+            val buf = new Array[Byte](2048)
+            client.getInputStream.read(buf)
+            val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
+            w.write(rawResponse)
+            w.flush()
+          } finally client.close()
+        } catch { case NonFatal(_) => () }
+      })
+      t.setDaemon(true)
+      t.start()
+      val uri = new URI(s"http://localhost:${server.getLocalPort}/myproject/_packaging/myfeed/maven/v1")
+      test(uri)
+      t.join(5000)
+    } finally server.close()
+  }
+
+  "getRealm" should "extract Basic realm from a realistic ADO 401 response" in {
+    // Real ADO response shape — multiple WWW-Authenticate challenges, Basic
+    // is not first. The plugin must specifically pick the Basic one.
+    val response =
+      "HTTP/1.1 401 Unauthorized\r\n" +
+      "Content-Length: 0\r\n" +
+      "WWW-Authenticate: Bearer authorization_uri=https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\r\n" +
+      "WWW-Authenticate: Basic realm=\"https://pkgsprodsu3weu.pkgs.visualstudio.com/\"\r\n" +
+      "WWW-Authenticate: TFS-Federated\r\n" +
+      "X-TFS-ProcessId: 11111111-1111-1111-1111-111111111111\r\n" +
+      "Connection: close\r\n\r\n"
+    withHttpServer(response) { uri =>
+      new RealmProbe().probe(uri) shouldBe Some("https://pkgsprodsu3weu.pkgs.visualstudio.com/")
+    }
+  }
+
+  it should "return None when no Basic challenge is present" in {
+    val response =
+      "HTTP/1.1 401 Unauthorized\r\n" +
+      "WWW-Authenticate: Bearer authorization_uri=https://login.microsoftonline.com/...\r\n" +
+      "WWW-Authenticate: TFS-Federated\r\n\r\n"
+    withHttpServer(response) { uri =>
+      new RealmProbe().probe(uri) shouldBe None
+    }
+  }
+
+  it should "match the WWW-Authenticate header case-insensitively" in {
+    // Some servers/proxies normalise header names — the plugin should still match.
+    val response =
+      "HTTP/1.1 401 Unauthorized\r\n" +
+      "www-authenticate: Basic realm=\"https://lowercase.example/\"\r\n\r\n"
+    withHttpServer(response) { uri =>
+      new RealmProbe().probe(uri) shouldBe Some("https://lowercase.example/")
+    }
+  }
+
+  it should "return None when the HEAD request itself fails" in {
+    // Point at a port nothing is listening on. The probe catches the IOException
+    // and returns None.
+    val probe = new RealmProbe()
+    val uri = new URI("http://localhost:1/never-routable")
+    probe.probe(uri) shouldBe None
+  }
+
+  // ─── getToken / getTokenImpl (real implementation, fake TokenCredential) ─
+
+  /** Test subclass that injects a fake TokenCredential and exposes getToken. */
+  private class TokenProbe(cred: TokenCredential)
+      extends AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+    override protected def newCredential(): TokenCredential = cred
+    def fetch(): Option[String] = getToken()
+  }
+
+  "getToken" should "return Some(token) when the credential resolves successfully" in {
+    new TokenProbe(credentialReturning("ya29.fake-token")).fetch() shouldBe Some("ya29.fake-token")
+  }
+
+  it should "return None when the credential resolves to empty (null AccessToken)" in {
+    new TokenProbe(fakeCredential(Mono.empty[AccessToken]())).fetch() shouldBe None
+  }
+
+  it should "return None when the credential throws" in {
+    val boom = fakeCredential(Mono.error[AccessToken](new RuntimeException("simulated az failure")))
+    new TokenProbe(boom).fetch() shouldBe None
+  }
+
+  it should "cache the result across calls (newCredential invoked at most once)" in {
+    var calls = 0
+    val probe = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      override protected def newCredential(): TokenCredential = {
+        calls += 1
+        credentialReturning(s"call-$calls")
+      }
+      def fetch(): Option[String] = getToken()
+    }
+    probe.fetch() shouldBe Some("call-1")
+    probe.fetch() shouldBe Some("call-1") // cached
+    probe.fetch() shouldBe Some("call-1") // still cached
+    calls shouldBe 1
+  }
+
+  it should "restore the previous Azure-identity log level after token acquisition" in {
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    try {
+      System.setProperty(prop, "debug")
+      new TokenProbe(credentialReturning("x")).fetch()
+      System.getProperty(prop) shouldBe "debug"
+    } finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
+  }
+
+  it should "clear the Azure-identity log level when none was set before" in {
+    val prop = "org.slf4j.simpleLogger.log.com.azure.identity"
+    val original = Option(System.getProperty(prop))
+    System.clearProperty(prop)
+    try {
+      new TokenProbe(credentialReturning("x")).fetch()
+      Option(System.getProperty(prop)) shouldBe None
+    } finally {
+      original.foreach(System.setProperty(prop, _))
+    }
+  }
+
+  // ─── updateCoursierConf ─────────────────────────────────────────────────
+
+  "updateCoursierConf" should "add authentication for MavenRepos with matching credentials" in {
+    val resolver = MavenRepository(
+      "AdoFeed", "https://pkgs.dev.azure.com/myorg/_packaging/myfeed/maven/v1")
+    val cred = Credentials("realm", "pkgs.dev.azure.com", "user1", "pat1")
+    val conf = CoursierConfiguration()
+    val result = AzureDevOpsCredentialsPlugin.updateCoursierConf(conf, Seq(resolver), Seq(cred))
+    val auth = result.authenticationByRepositoryId.toMap.get("AdoFeed")
+    auth shouldBe Some(Authentication("user1", "pat1"))
+  }
+
+  it should "leave the conf unchanged when no credentials match" in {
+    val resolver = MavenRepository(
+      "AdoFeed", "https://pkgs.dev.azure.com/myorg/_packaging/myfeed/maven/v1")
+    val cred = Credentials("realm", "some.other.host", "user1", "pat1")
+    val conf = CoursierConfiguration()
+    val result = AzureDevOpsCredentialsPlugin.updateCoursierConf(conf, Seq(resolver), Seq(cred))
+    result.authenticationByRepositoryId shouldBe conf.authenticationByRepositoryId
+  }
+
+  it should "ignore non-MavenRepo resolvers" in {
+    val resolver: Resolver = Resolver.file("local-ivy", new File("/tmp"))
+    val cred = Credentials("realm", "pkgs.dev.azure.com", "user1", "pat1")
+    val conf = CoursierConfiguration()
+    val result = AzureDevOpsCredentialsPlugin.updateCoursierConf(conf, Seq(resolver), Seq(cred))
+    result.authenticationByRepositoryId shouldBe conf.authenticationByRepositoryId
+  }
+
+  it should "ignore non-DirectCredentials entries" in {
+    // FileCredentials are an example of a non-DirectCredentials Credentials.
+    val resolver = MavenRepository(
+      "AdoFeed", "https://pkgs.dev.azure.com/myorg/_packaging/myfeed/maven/v1")
+    val fileCred: Credentials = Credentials(new File("/nonexistent/cred"))
+    val conf = CoursierConfiguration()
+    val result = AzureDevOpsCredentialsPlugin.updateCoursierConf(
+      conf, Seq(resolver), Seq(fileCred))
+    result.authenticationByRepositoryId shouldBe conf.authenticationByRepositoryId
+  }
+
+  it should "add authentication for multiple repositories independently" in {
+    val r1 = MavenRepository("R1", "https://pkgs.dev.azure.com/orgA/_packaging/feed/maven/v1")
+    val r2 = MavenRepository("R2", "https://pkgs.dev.azure.com/orgB/_packaging/feed/maven/v1")
+    val c1 = Credentials("realm", "pkgs.dev.azure.com", "userAB", "patAB")
+    val conf = CoursierConfiguration()
+    val result = AzureDevOpsCredentialsPlugin.updateCoursierConf(conf, Seq(r1, r2), Seq(c1))
+    val byId = result.authenticationByRepositoryId.toMap
+    byId.get("R1") shouldBe Some(Authentication("userAB", "patAB"))
+    byId.get("R2") shouldBe Some(Authentication("userAB", "patAB"))
+  }
+
+  // ─── AutoPlugin metadata ────────────────────────────────────────────────
+
+  "AzureDevOpsCredentialsPlugin" should "trigger on all requirements" in {
+    // sbt.plugins.JvmPlugin uses allRequirements too; compare against that.
+    AzureDevOpsCredentialsPlugin.trigger shouldBe sbt.plugins.JvmPlugin.trigger
+  }
+
+  // ─── Default hook implementations (no overrides) ────────────────────────
+
+  "CredentialsBuilder defaults" should "expose a default Maven settings file at ~/.m2/settings.xml" in {
+    val probe = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      def file: File = mavenSettingsFile
+    }
+    probe.file.getPath should endWith (s"${File.separator}.m2${File.separator}settings.xml")
+  }
+
+  it should "create a non-null TokenCredential chain by default" in {
+    val probe = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      def cred: TokenCredential = newCredential()
+    }
+    probe.cred should not be null
+  }
+
+  // ─── headRequestHeaders edge cases ─────────────────────────────────────
+
+  // Reuses the server helper at file-level scope. We send a response where one
+  // line is malformed (no colon) — the parser must skip it and keep going.
+  private def withRawHeadServer(rawResponse: String)(test: (String, Int) => Unit): Unit = {
+    val server = new ServerSocket(0)
+    try {
+      val port = server.getLocalPort
+      val t = new Thread(() => {
+        try {
+          val client = server.accept()
+          try {
+            val buf = new Array[Byte](2048)
+            client.getInputStream.read(buf)
+            val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
+            w.write(rawResponse)
+            w.flush()
+          } finally client.close()
+        } catch { case NonFatal(_) => () }
+      })
+      t.setDaemon(true)
+      t.start()
+      test("localhost", port)
+      t.join(5000)
+    } finally server.close()
+  }
+
+  "headRequestHeaders" should "skip header lines that don't contain a colon" in {
+    val response =
+      "HTTP/1.1 401 Unauthorized\r\n" +
+      "this-line-has-no-colon\r\n" +
+      "Good-Header: ok\r\n\r\n"
+    withRawHeadServer(response) { (host, port) =>
+      val uri = new URI(s"http://$host:$port/")
+      val headers = AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+      headers should contain ("Good-Header" -> "ok")
+      headers.map(_._1) should not contain "this-line-has-no-colon"
+    }
+  }
+
+  it should "wrap the socket with SSLSocketFactory when the scheme is https" in {
+    // Point an https URI at a plain-HTTP test server. The TLS handshake will
+    // fail (the server is speaking HTTP/1.1), but the wrap-with-SSL path on
+    // line ~128 still runs. The plugin propagates the error to getRealm which
+    // converts it to None — but here we just assert headRequestHeaders throws,
+    // which proves we entered the SSL wrap branch.
+    withRawHeadServer("HTTP/1.1 200 OK\r\n\r\n") { (host, port) =>
+      val uri = new URI(s"https://$host:$port/")
+      an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+    }
+  }
+
+  it should "default to port 80 for http URIs with no explicit port" in {
+    // Hit a TCP server we just started, but address it via a URI that has no
+    // explicit port. We can't bind port 80 in CI, so instead we use 127.0.0.2
+    // (a localhost alias that is guaranteed unreachable) — the connect attempt
+    // exercises the "scheme == http, no port -> 80" branch even though the
+    // actual TCP connect fails.
+    val uri = new URI("http://127.0.0.2/")
+    // Either the connect times out or it's refused; either way the function
+    // throws, which is what we want to assert.
+    an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+  }
+
+  it should "default to port 443 for https URIs with no explicit port" in {
+    val uri = new URI("https://127.0.0.2/")
+    an[Exception] should be thrownBy AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+  }
+}

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLException
 
 import scala.util.control.NonFatal
 
+import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -34,7 +35,17 @@ import lmcoursier.definitions.Authentication
 import com.azure.core.credential.{AccessToken, TokenCredential, TokenRequestContext}
 import reactor.core.publisher.Mono
 
-class CredentialsBuilderSpec extends AnyFlatSpec with Matchers {
+class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
+
+  // Defense in depth for the JVM-global suppression counter. `before` catches
+  // contamination from another spec running in the same JVM; `after` pins any
+  // leak in *this* spec to the exact test that caused it (otherwise a leak
+  // surfaces as a confusing assertion failure in the next test that reads
+  // the Azure-identity log-level property — see the nested-suppression test
+  // for the canonical "wrong saved value" symptom that would result). We
+  // assert rather than reset so leaks remain visible instead of being masked.
+  before { AzureDevOpsCredentialsPlugin.suppressionCountForTesting shouldBe 0 }
+  after  { AzureDevOpsCredentialsPlugin.suppressionCountForTesting shouldBe 0 }
 
   // ─── Test fixtures ─────────────────────────────────────────────────────
 

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -471,6 +471,24 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
+  it should "throw IllegalArgumentException when release is called without a matching acquire" in {
+    // Regression guard for the unbalanced-release silent-corruption mode:
+    // without the `require(suppressionCount > 0, ...)` in release, an
+    // unmatched release would decrement the counter to -1; the next acquire
+    // would see suppressionCount == 0 is false (it's -1), skip the save+set,
+    // and just bump to 0. The suppression then becomes a silent no-op for the
+    // rest of the JVM run — counter looks healthy from the outside (returns
+    // to 0 again on the next acquire/release pair) but the property is never
+    // saved or restored. `require` makes the failure mode loud at the actual
+    // bad caller instead.
+    an[IllegalArgumentException] should be thrownBy {
+      AzureDevOpsCredentialsPlugin.releaseAzureIdentityLogSuppression()
+    }
+    // Counter remains at 0 because `require` throws before any mutation.
+    // (Also cross-checked by the per-test BeforeAndAfter `after` hook.)
+    AzureDevOpsCredentialsPlugin.suppressionCountForTesting shouldBe 0
+  }
+
   // ─── updateCoursierConf ─────────────────────────────────────────────────
 
   "updateCoursierConf" should "add authentication for MavenRepos with matching credentials" in {


### PR DESCRIPTION
## Fix

`WorkloadIdentityCredentialBuilder.build()` is now invoked only when its three required env vars — `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` — are all present and non-empty after trimming. When any is absent, empty, or whitespace-only (the typical state on a developer workstation), the credential is omitted from the chain instead of failing chain assembly eagerly with `IllegalArgumentException`. This is the direct fix for the v0.0.8 regression where `ChainedTokenCredentialBuilder` couldn't be assembled at all on workstations that had `az login` working but no workload-identity env vars set, leaving the plugin to always report `"failed to get access token. Did you forget to run \`az login\`?"`.

## What's in this PR

- **The fix itself** — explicit env-var check before `WorkloadIdentityCredentialBuilder.build()`, env-var values trimmed before being passed to the SDK.
- **Test infrastructure** — first unit-test suite on this repo (the v0.0.8 regression was uncaught because the only tests were `AZURE_DEVOPS_TEST_URL`-gated integration tests). `CredentialsBuilderSpec` and `AzureDevOpsCredentialsPluginSpec` together cover every code path with realistic ADO fixtures: `WWW-Authenticate` challenge ordering matching actual `pkgs.dev.azure.com` 401 responses, both modern (`pkgs.dev.azure.com/{org}`) and legacy (`{org}.pkgs.visualstudio.com`) feed URL formats, the `Mono.just / Mono.empty / Mono.error` branches of `getTokenImpl`, etc.
- **CI** — GitHub Actions workflow running `sbt -batch clean coverage test coverageReport` on JDK 8 / 11 / 17 / 21 against every PR and every push to `master`. Coverage results are emitted to `GITHUB_STEP_SUMMARY` per-Java-version and the full HTML report is uploaded as a build artifact. Coverage gate: `coverageMinimumStmt/BranchTotal := 100` + `coverageFailOnMinimum := true`.
- **Log-suppression safety net** — a counted-set acquire/release path (`acquireAzureIdentityLogSuppression` / `releaseAzureIdentityLogSuppression`) replaces v0.0.8's per-call save/restore. Multi-project sbt builds that resolve credentials in parallel now share one suppression window without holding a JVM-wide lock across the slow Azure SDK call. A static initializer at plugin classloading sets `org.slf4j.simpleLogger.log.com.azure.identity` to `"off"` if unset, defending against SLF4J `SimpleLogger`'s per-logger init-time level caching (a later `setProperty` doesn't affect already-instantiated loggers, so an upstream plugin that touches `azure-*` before us could otherwise silently disable the counted-set suppression for the rest of the JVM run). Pre-existing user values (e.g. `-Dorg.slf4j.simpleLogger.log.com.azure.identity=debug` for diagnostics) are respected.

## Compatibility

- **`CredentialsBuilder` constructor: source-compatible at the API level, binary-incompatible at the bytecode level.** The constructor parameter widens from `sbt.internal.util.ManagedLogger` to `sbt.util.Logger`. All existing callers continue to compile and run identically because `ManagedLogger <: Logger`, but anyone hand-instantiating `CredentialsBuilder` from compiled bytecode would need to recompile. The class is effectively internal — only `projectSettings` constructs it — so this should be a non-event in practice, but it's called out in the v0.0.9 release notes.
- **CredentialsBuilder extension surface widened from `private` to `protected`.** Four methods on `CredentialsBuilder` — `mavenSettingsFile`, `newCredential`, `getRealm`, `getToken` — went from `private` to `protected` so the new unit tests can substitute them via anonymous subclasses. `class CredentialsBuilder` itself is unqualified-public, so a third-party sbt build can now subclass it and override these methods. In practice there's no public extension *point* (only `projectSettings` instantiates `CredentialsBuilder`) so the impact is near-zero, but the visible API surface did grow — a future re-tightening to `private` would technically need a SemVer-major bump or a deprecation cycle to walk back.
- **Package-private surface tightened to `private[chungmin]`.** All package-private members on `AzureDevOpsCredentialsPlugin` use `private[chungmin]` (not `private[sbt]`). The plugin lives in `dev.chungmin.sbt`, so Scala resolves `private[sbt]` to `private[dev.chungmin.sbt]` — visible only to this leaf package, never to the global `sbt` ecosystem. `private[chungmin]` resolves to `dev.chungmin.*` unambiguously, which is the test code's parent package. Same effective access as before; strictly clearer intent.
- **`org.slf4j.simpleLogger.log.com.azure.identity` is now baselined to `"off"` at plugin classloading time**, not just inside `getToken` calls. Pre-PR the suppression was strictly scoped to `getTokenImpl`'s `try`/`finally`. Post-PR, if another sbt plugin pulls in `azure-identity` for its own use (azure-storage-blob, azure-keyvault, azure-cosmos, …), that plugin's `com.azure.identity` logs are also suppressed across the whole sbt run. This is a deliberate trade-off — without static-init, SLF4J's per-logger init-cache would silently break our in-call suppression — but the broader scope is worth a dedicated release-notes mention. A pre-existing user value survives plugin classloading, so `-Dorg.slf4j.simpleLogger.log.com.azure.identity=debug` works as an opt-out.
- **`Test / parallelExecution := false`** in `build.sbt`. Affects only test-suite execution semantics for `sbt test` (the test code itself is unchanged for downstream users — they don't run the plugin's tests). Multiple suites mutate the JVM-global property; serializing suite execution closes the cross-suite race window. Cost is negligible at this scale (~1.4s for 62 tests serial vs ~1.1s parallel).

## Why this wasn't caught at v0.0.8

There were no unit tests for `createCredential` — only integration tests gated on `AZURE_DEVOPS_TEST_URL` (which auto-skip in the absence of that env var) and no CI of any kind. This PR closes that gap so the same class of bug can't sneak through again.

## v0.0.9 release notes — draft

1. **Fix:** `WorkloadIdentityCredential` is now skipped from the chain when its `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` env vars are absent, empty, or whitespace-only. Fixes the v0.0.8 regression: `IllegalArgumentException` at chain assembly on any developer workstation that has `az login` working but no workload-identity env vars set.
2. **Behavior change:** Concurrent `CredentialsBuilder` instances (multi-project sbt builds resolving credentials in parallel) now share a reference-counted log-suppression instead of holding a JVM-wide lock across the Azure SDK call. Token fetches actually run in parallel; the `org.slf4j.simpleLogger.log.com.azure.identity` property is restored correctly after the last in-flight builder completes.
3. **Behavior change — broadened suppression scope:** `org.slf4j.simpleLogger.log.com.azure.identity` is now set to `"off"` at plugin classloading time if it isn't already set, defending against SLF4J SimpleLogger's per-logger init-time level caching. Pre-v0.0.9, suppression was strictly scoped to `getToken` calls — but if anything else in the JVM (another sbt plugin pulling in `azure-*` transitively, an upstream setting calling `az`, a `console` task) initialized a `com.azure.identity` logger before our first `getToken`, the per-call suppression silently no-op'd for the rest of the run. As a side effect, other plugins that consume `azure-identity` directly (azure-storage-blob, azure-keyvault, …) will now have their `com.azure.identity` logs suppressed across the whole sbt run too — set `-Dorg.slf4j.simpleLogger.log.com.azure.identity=debug` (or any non-`off` value) via JVM args to opt out.
4. **Behavior change:** AAD env-var values are now `.trim`med before being passed to the SDK, so a stray trailing newline (e.g. from a YAML literal-block substitution leaving whitespace around the value) is tolerated instead of producing a credential that builds successfully but fails AAD validation at `getToken` time.
5. **Behavior change — test execution:** `Test / parallelExecution := false` in `build.sbt` to close the cross-suite property-race window. Only affects `sbt test` of this repository, not downstream consumers of the plugin.
6. **Internal correctness:** `releaseAzureIdentityLogSuppression` now throws `IllegalArgumentException` when called without a matching prior `acquire`. The method is `private[chungmin]` and only invoked internally by `getTokenImpl`'s `try`/`finally`, so end users won't see this in practice — but it's a behavior change for anyone embedding the plugin and calling the suppression API directly. Previously an unbalanced release silently corrupted the counter, leaving the suppression dead for the rest of the JVM run; now it fails fast at the actual bad caller.
7. **API surface change:** Four `CredentialsBuilder` methods (`mavenSettingsFile`, `newCredential`, `getRealm`, `getToken`) widened from `private` to `protected` to enable unit-test substitution via anonymous subclasses. `class CredentialsBuilder` is unqualified-public, so this technically expands the downstream extension surface, even though there's no public extension point in practice (only `projectSettings` instantiates the class). Flagged so a future re-tightening to `private` is treated as the SemVer-major / deprecation-cycle change it would be, not a silent revert.
8. **Binary-incompatible:** `CredentialsBuilder` constructor parameter widened from `sbt.internal.util.ManagedLogger` to `sbt.util.Logger`. Source-compatible; binary-incompatible. The class is effectively internal — only constructed by the plugin's own `projectSettings` task wiring — so this should be invisible to downstream users in practice.