### PR TITLE
feat: probe stale settings.xml entries and fall through to Entra

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,44 @@ Requirements:
 Add the following lines to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("dev.chungmin" % "sbt-azure-devops-credentials" % "0.0.9")
+addSbtPlugin("dev.chungmin" % "sbt-azure-devops-credentials" % "0.0.10")
 ```
 
 You should log in to Azure by using `az login`. Once you're logged in, the plugin will
 create access tokens for the Maven feeds from Azure DevOps.
 
 This plugin first checks if the credentials are already in `~/.m2/settings.xml`.
-If credentials are found in the Maven settings file, token creation is skipped for the found hosts.
+If credentials are found in the Maven settings file, the plugin probes the feed
+with those credentials and falls through to Entra token acquisition only if the
+probe returns `401` (i.e., the existing entry is stale). Valid entries are
+trusted as before — no extra round-trips on the happy path.
+
+## Configuring credential validation
+
+The probe behavior is controlled by `dev.chungmin.azure.validateExistingCredentials`
+(values: `auto` (default), `always`, `never`).
+
+| Mode | On 401 + Entra reachable | On 401 + Entra unreachable | Use case |
+|---|---|---|---|
+| `auto` (default) | Drop entry, use Entra | Keep entry, log INFO | Recover from stale PATs automatically; same outcome as today when Entra is also unavailable |
+| `always` | Drop entry, use Entra | Drop entry, Entra error surfaces | Force Entra path; surfaces Entra-side failures with actionable errors |
+| `never` | Trust entry | Trust entry | Pre-0.0.10 behavior — disables the probe entirely |
+
+Set via any of:
+
+```bash
+# CLI
+sbt -Ddev.chungmin.azure.validateExistingCredentials=always update
+
+# .jvmopts (per-project, checked in)
+echo "-Ddev.chungmin.azure.validateExistingCredentials=always" >> .jvmopts
+
+# SBT_OPTS (per-host or CI)
+export SBT_OPTS="$SBT_OPTS -Ddev.chungmin.azure.validateExistingCredentials=always"
+
+# build.sbt (per-project, idiomatic)
+azureDevOpsValidateExistingCredentials := "always"
+```
 
 # Example
 
@@ -30,6 +60,12 @@ You can run `sbt 'show credentials'` to check if the credentials are populated c
 # Limitations
 
 This plugin only supports Azure DevOps Services (cloud). Azure DevOps Server (on-premises) is not supported, as it uses custom domains that cannot be auto-detected.
+
+**Multi-feed-per-host with mixed valid + stale `<server>` entries** (tracked: #7). sbt's credential model is host-keyed (not resolver-name-keyed). When two `<server>` entries in `~/.m2/settings.xml` resolve to the same host (e.g., `<server id="FeedA">` and `<server id="FeedB">`, both serving feeds at `pkgs.dev.azure.com/...`), and one PAT is valid while the other is stale, dropping the stale one doesn't produce an Entra fallback for that specific feed — the still-valid entry occupies the host slot in sbt's credential lookup, and the dropped feed inherits the other entry's credentials. Subsequent fetches against the dropped feed will 401 because the valid PAT isn't scoped to it. Workarounds:
+
+- Consolidate so that a host has a single PAT that's scoped to all its feeds you use, OR
+- Set `azureDevOpsValidateExistingCredentials := "never"` so the legacy "trust both, let the fetch fail" behavior surfaces, OR
+- Use distinct hostnames per feed (legacy `<org>.pkgs.visualstudio.com` form keys orgs into separate hostnames).
 
 # Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements:
 Add the following lines to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("dev.chungmin" % "sbt-azure-devops-credentials" % "0.0.10")
+addSbtPlugin("dev.chungmin" % "sbt-azure-devops-credentials" % "0.0.9")
 ```
 
 You should log in to Azure by using `az login`. Once you're logged in, the plugin will

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ trusted as before — no extra round-trips on the happy path.
 The probe behavior is controlled by `dev.chungmin.azure.validateExistingCredentials`
 (values: `auto` (default), `always`, `never`).
 
-| Mode | On 401 + Entra reachable | On 401 + Entra unreachable | Use case |
-|---|---|---|---|
-| `auto` (default) | Drop entry, use Entra | Keep entry, log INFO | Recover from stale PATs automatically; same outcome as today when Entra is also unavailable |
-| `always` | Drop entry, use Entra | Drop entry, Entra error surfaces | Force Entra path; surfaces Entra-side failures with actionable errors |
-| `never` | Trust entry | Trust entry | Pre-0.0.10 behavior — disables the probe entirely |
+| Mode | 401 + Entra reachable + new token works for feed | 401 + Entra reachable but new token has no feed access | 401 + Entra unreachable | Use case |
+|---|---|---|---|---|
+| `auto` (default) | Drop entry, use Entra | Keep entry, log INFO about Entra identity scope | Keep entry, log INFO with `az login` remediation | Recover from stale PATs automatically; falls back to trusting settings.xml when Entra also can't help (e.g. Managed Identity without feed access) |
+| `always` | Drop entry, use Entra | Drop entry (no Bearer-verify in `always` mode); fetch then 401s and sbt/coursier surfaces the error | Drop entry, Entra error surfaces (`WARN` from `getTokenImpl`) | Force Entra path; surfaces Entra-side failures with actionable errors |
+| `never` | Trust entry | Trust entry | Trust entry | Pre-0.0.10 behavior — disables the probe entirely |
 
 Set via any of:
 

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -536,7 +536,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
     /** Backward-compat overload: reads the mode from
       * [[ValidateExistingCredentialsProperty]] at construction time (preserves
-      * the v0.0.10 internal-API shape used by tests). */
+      * the single-arg constructor shape used by existing tests). */
     def this(log: Logger) =
       this(log, AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode())
 

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -764,20 +764,30 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       * entry is stale. Returns `true` if the entry should be dropped (stale),
       * `false` if it should be kept (trusted).
       *
-      * Public-but-`protected[chungmin]` is intentional: the suffix `Impl` and
-      * the visibility are the test-injection seam. Tests in
-      * `dev.chungmin.sbt` override this method to inject specific
-      * `(probeWithBasic, probeWithBearer)` outcomes and assert the
-      * decision-tree branches in isolation — for example, `probeAndDecide
-      * (auto, Entra works, Bearer probe ALSO 401)` overrides this with a
-      * canned `false` to bypass the real probe while exercising the
-      * surrounding `isStaleSettingsEntry` flow.
+      * Public-but-`protected[chungmin]` is intentional — it makes this method
+      * one of two test-injection seams used by the spec, depending on what the
+      * test wants to assert:
+      *
+      *  - Tests that want to assert the surrounding wiring (cache hits, mode
+      *    short-circuits, `isStaleSettingsEntry` host/scheme gates) override
+      *    `probeAndDecideImpl` itself with a canned outcome. The
+      *    "actually cache in the real implementation" test in
+      *    `CredentialsBuilderSpec.scala` is an example: it overrides this
+      *    method to return `true` and counts call sites, so the surrounding
+      *    `computeIfAbsent` is what's actually under test.
+      *  - Tests that want to assert THIS method's decision tree
+      *    (Basic-probe 401 → auto/always fork → Bearer-verify 401 → keep, etc.)
+      *    leave `probeAndDecideImpl` intact and instead override
+      *    [[probeWithBasic]] / [[probeWithBearer]] (their own Scaladoc explains
+      *    that seam separately). The `isStaleSettingsEntry decision tree`
+      *    tests in `CredentialsBuilderSpec.scala` use this pattern via
+      *    `stubProbeBuilder`.
       *
       * `mode` is passed explicitly as an argument (not read from the
-      * enclosing builder's `mode` field) so a test override can assert
-      * decision-tree behaviour against an arbitrary mode value without
-      * constructing a separate builder per mode. Production's only call
-      * site (in [[isStaleSettingsEntry]]) passes the builder's `mode`
+      * enclosing builder's `mode` field) so a test override of EITHER seam
+      * can assert decision-tree behaviour against an arbitrary mode value
+      * without constructing a separate builder per mode. Production's only
+      * call site (in [[isStaleSettingsEntry]]) passes the builder's `mode`
       * field verbatim — do not collapse the parameter into a `this.mode`
       * read without removing the test-injection seam, or the per-call mode
       * argument silently stops mattering. */

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -18,7 +18,7 @@ package dev.chungmin.sbt
 import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
 import java.net.{InetSocketAddress, Socket}
 
-import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.{SSLSocket, SSLSocketFactory}
 
 import scala.util.control.NonFatal
 import scala.xml.XML
@@ -43,6 +43,23 @@ import com.azure.identity.{
 object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
+  object autoImport {
+    /** Controls how `~/.m2/settings.xml` `<server>` entries are validated
+      * against the feed before being trusted.
+      *
+      * Values: `"auto"` (default), `"always"`, `"never"`. See
+      * [[AzureDevOpsCredentialsPlugin.ValidateExistingCredentialsProperty]]
+      * for full semantics. Defaults to the value of
+      * `-Ddev.chungmin.azure.validateExistingCredentials=...` at task
+      * evaluation time, and overrides that property for the project it's
+      * scoped to — per-project, not JVM-global. In a multi-project build,
+      * two projects can have different validation modes via this setting
+      * (impossible via the `-D` property alone). */
+    val azureDevOpsValidateExistingCredentials =
+      settingKey[String]("Validate ~/.m2/settings.xml entries against feeds: auto|always|never")
+  }
+  import autoImport._
+
   // NOTE on the package-private modifier used throughout this file:
   // `private[chungmin]` (not `private[sbt]`) is deliberate. The plugin's
   // package is `dev.chungmin.sbt`, so Scala's enclosing-package resolution
@@ -56,6 +73,37 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
   /** Azure DevOps resource scope for access tokens. */
   private[chungmin] val AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default"
+
+  /** System property controlling whether existing `~/.m2/settings.xml`
+    * `<server>` entries are probed against the feed before being trusted.
+    *
+    * Values (case-insensitive):
+    *
+    *   - `"auto"` (default): probe each entry with a HEAD request; if the
+    *     feed returns 401 AND Entra acquisition succeeds, drop the entry and
+    *     fall through to the Entra path. If Entra is unreachable, keep the
+    *     stale entry and log an INFO line — same outcome as the legacy
+    *     behavior, but with diagnostic signal.
+    *   - `"always"`: probe; on 401, drop unconditionally (Entra's failure
+    *     becomes the user-visible error if it can't acquire either).
+    *   - `"never"`: legacy behavior — trust settings.xml entries
+    *     unconditionally.
+    *
+    * Configurable as `-D` JVM property, in `.jvmopts`, or via `SBT_OPTS`.
+    * The `build.sbt` setting [[autoImport.azureDevOpsValidateExistingCredentials]]
+    * defaults to this property's value and is passed directly into
+    * [[CredentialsBuilder]] at task evaluation time — taking precedence over
+    * this property for the project it's scoped to. The setting deliberately
+    * does NOT write back to the system property (which is JVM-global) so
+    * per-project overrides don't leak across projects in a multi-module
+    * build. */
+  private[chungmin] val ValidateExistingCredentialsProperty =
+    "dev.chungmin.azure.validateExistingCredentials"
+
+  /** Legal values for [[ValidateExistingCredentialsProperty]]. */
+  private[chungmin] val ValidateAuto = "auto"
+  private[chungmin] val ValidateAlways = "always"
+  private[chungmin] val ValidateNever = "never"
 
   /** System property to control Azure Identity SDK logging.
     * Set to "off" during token acquisition to suppress expected [ERROR] messages
@@ -276,12 +324,21 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     else if (uri.getScheme == "https") 443
     else 80
 
-  /** Send an unauthenticated HEAD request and return the response headers.
+  /** Send a HEAD request with optional credentials and return both the
+    * response status code (parsed from the first line) and the response
+    * headers.
     *
     * Uses a raw socket instead of HttpURLConnection to avoid triggering
-    * sbt's global IvyAuthenticator, which logs spurious "Unable to find
-    * credentials" error messages when the server responds with 401. */
-  private[chungmin] def headRequestHeaders(uri: URI): Seq[(String, String)] = {
+    * sbt's global IvyAuthenticator (which logs spurious "Unable to find
+    * credentials" errors on 401) AND to keep the Authorization header
+    * from being logged by Aether/sbt's HTTP transport layer — a
+    * non-trivial PAT-leakage hazard since 0.0.9 added the probe path.
+    *
+    * The authorization header (if provided) is set exactly once and never
+    * re-sent on a redirect (we don't follow them — the response line is
+    * read and returned verbatim). */
+  private[chungmin] def headRequest(
+      uri: URI, authHeader: Option[String]): (Option[Int], Seq[(String, String)]) = {
     val host = uri.getHost
     val port = defaultPort(uri)
     val path = Option(uri.getRawPath).filter(_.nonEmpty).getOrElse("/")
@@ -290,21 +347,39 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       rawSocket.connect(new InetSocketAddress(host, port), 10000)
       rawSocket.setSoTimeout(10000)
       val socket = if (uri.getScheme == "https") {
-        SSLSocketFactory.getDefault.asInstanceOf[SSLSocketFactory]
+        val sslSocket = SSLSocketFactory.getDefault.asInstanceOf[SSLSocketFactory]
           .createSocket(rawSocket, host, port, /* autoClose = */ true)
+          .asInstanceOf[SSLSocket]
+        // Enable HTTPS endpoint identification: verifies the server cert's
+        // CN/SAN matches the URI's host. Raw SSLSocket does cert-chain
+        // validation by default but skips hostname matching unless we opt in
+        // here (documented JDK behavior through 21+). Critical for the v0.0.10
+        // authenticated-probe path: we now put PATs (Basic) and Entra tokens
+        // (Bearer) on the wire via this helper, so a misissued cert from a
+        // publicly-trusted CA + DNS hijack would otherwise read credentials
+        // off the wire. Pre-v0.0.10 the helper only sent unauthenticated
+        // realm-detection probes, so the gap was harmless then.
+        configureSslEndpointIdentification(sslSocket)
       } else {
         rawSocket
       }
       try {
         val writer = new BufferedWriter(
           new OutputStreamWriter(socket.getOutputStream, "UTF-8"))
+        val authLine = authHeader.map(h => s"Authorization: $h\r\n").getOrElse("")
         writer.write(
-          s"HEAD $path HTTP/1.1\r\nHost: $host\r\nConnection: close\r\n\r\n")
+          s"HEAD $path HTTP/1.1\r\nHost: $host\r\n${authLine}Connection: close\r\n\r\n")
         writer.flush()
         val reader = new BufferedReader(
           new InputStreamReader(socket.getInputStream, "UTF-8"))
         val headers = Seq.newBuilder[(String, String)]
-        reader.readLine() // skip status line
+        // Parse the status line: "HTTP/1.1 401 Unauthorized" -> Some(401).
+        // Tolerant parse: any malformed status line returns None.
+        val statusLine = reader.readLine()
+        val status: Option[Int] = Option(statusLine).flatMap { line =>
+          val parts = line.split(" ", 3)
+          if (parts.length >= 2) scala.util.Try(parts(1).toInt).toOption else None
+        }
         var line = reader.readLine()
         while (line != null && line.nonEmpty) {
           val colon = line.indexOf(':')
@@ -313,7 +388,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
           }
           line = reader.readLine()
         }
-        headers.result()
+        (status, headers.result())
       } finally {
         socket.close()
       }
@@ -324,10 +399,91 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     }
   }
 
+  /** Send an unauthenticated HEAD request and return the response headers.
+    *
+    * Thin wrapper over [[headRequest]] for callers that only need headers
+    * (e.g. realm detection). Status-code consumers should use [[headRequest]]
+    * directly. */
+  private[chungmin] def headRequestHeaders(uri: URI): Seq[(String, String)] =
+    headRequest(uri, authHeader = None)._2
+
+  /** Enable HTTPS endpoint identification on a freshly-created
+    * [[javax.net.ssl.SSLSocket]] so the TLS handshake verifies the server's
+    * cert CN/SAN matches the URI's host. Returns the same socket reference
+    * for chaining.
+    *
+    * Extracted as a testable helper because a unit test for the underlying
+    * intent ("the socket asks for hostname verification") is much cleaner
+    * than spinning up a self-signed-cert HTTPS test server just to observe
+    * the resulting [[javax.net.ssl.SSLHandshakeException]] — the JDK already
+    * enforces the algorithm once it's set; we only need to assert the call
+    * site sets it. */
+  private[chungmin] def configureSslEndpointIdentification(socket: SSLSocket): SSLSocket = {
+    val params = socket.getSSLParameters
+    params.setEndpointIdentificationAlgorithm("HTTPS")
+    socket.setSSLParameters(params)
+    socket
+  }
+
+  /** Build the Basic auth header value (`"Basic <base64(user:pass)>"`)
+    * from a username/password pair. Pure helper, no I/O. */
+  private[chungmin] def basicAuthHeader(user: String, pass: String): String = {
+    val raw = s"$user:$pass".getBytes("UTF-8")
+    "Basic " + java.util.Base64.getEncoder.encodeToString(raw)
+  }
+
+  /** Normalize a raw mode string (from `-D`, sys.props, or the setting key) to
+    * one of the canonical lower-case values. Unknown / null / empty input
+    * falls back to the default (`"auto"`).
+    *
+    * Centralizes the lower-case + canonical-match logic so both the
+    * property-reader [[validateExistingCredentialsMode]] AND the
+    * [[CredentialsBuilder]] two-arg constructor go through the same
+    * normalization — preventing the case-sensitivity regression where the
+    * production wiring would silently degrade `-D...=NEVER` or
+    * `:= "Always"` to the auto branch. */
+  private[chungmin] def normalizeMode(value: String): String =
+    Option(value).map(_.toLowerCase) match {
+      case Some(ValidateAlways) => ValidateAlways
+      case Some(ValidateNever) => ValidateNever
+      case _ => ValidateAuto
+    }
+
+  /** Read [[ValidateExistingCredentialsProperty]] and normalize the value to
+    * one of `"auto" | "always" | "never"`. Unknown / null values fall back
+    * to the default (`"auto"`).
+    *
+    * Exposed for testability so the property-precedence logic is directly
+    * assertable; the setting key in [[autoImport]] writes through to this
+    * property, so a unit test that sets the property exercises the same
+    * code path the setting-key wiring uses. */
+  private[chungmin] def validateExistingCredentialsMode(): String =
+    normalizeMode(System.getProperty(ValidateExistingCredentialsProperty))
+
+
   // $COVERAGE-OFF$ sbt task wiring — exercised only inside a real sbt build, not unit-testable
   override lazy val projectSettings = Seq(
-    credentials ++= new CredentialsBuilder(streams.value.log)
-      .buildCredentials(credentials.value, externalResolvers.value),
+    // Route through validateExistingCredentialsMode so the default is
+    // normalized (lowercased, unknown → "auto"). Critical: without this,
+    // `-D...=NEVER` would land as raw "NEVER" in the setting value, pass
+    // straight into CredentialsBuilder(log, mode), and silently degrade to
+    // auto because the constants are lowercase.
+    azureDevOpsValidateExistingCredentials := validateExistingCredentialsMode(),
+
+    credentials ++= {
+      // Pass the mode VALUE directly into CredentialsBuilder. Using a JVM-wide
+      // System property as the bridge would race across the per-project credentials
+      // tasks in a multi-project build (sbt may evaluate them in any order, and the
+      // System property is global). Direct argument-passing gives each project's
+      // CredentialsBuilder the mode that was actually scoped to it.
+      //
+      // CredentialsBuilder's constructor re-normalizes mode so a user who sets
+      // `azureDevOpsValidateExistingCredentials := "ALWAYS"` directly in build.sbt
+      // (bypassing the projectSettings default above) still gets correct behavior.
+      val mode = azureDevOpsValidateExistingCredentials.value
+      new CredentialsBuilder(streams.value.log, mode)
+        .buildCredentials(credentials.value, externalResolvers.value)
+    },
 
     // Fix for https://github.com/coursier/coursier/issues/1649
     csrConfiguration := updateCoursierConf(
@@ -337,7 +493,17 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   )
   // $COVERAGE-ON$
 
-  class CredentialsBuilder(log: Logger) {
+  class CredentialsBuilder(log: Logger, rawMode: String) {
+    // Normalize at construction time so all internal call sites can compare
+    // with `==` against the canonical lowercase constants without re-normalizing.
+    private val mode: String = AzureDevOpsCredentialsPlugin.normalizeMode(rawMode)
+
+    /** Backward-compat overload: reads the mode from
+      * [[ValidateExistingCredentialsProperty]] at construction time (preserves
+      * the v0.0.10 internal-API shape used by tests). */
+    def this(log: Logger) =
+      this(log, AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode())
+
     def buildCredentials(
         existingCredentials: Seq[Credentials],
         resolvers: Seq[Resolver]): Seq[Credentials] = {
@@ -481,9 +647,19 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
             val uri = new URI(repo.root)
             val host = uri.getHost
             val (user, password) = server
-            getRealm(uri).map { realm =>
-              log.debug(s"creating credentials for realm=$realm, host=$host, user=$user")
-              Credentials(realm, host, user, password)
+            if (isStaleSettingsEntry(uri, host, user, password)) {
+              // Probe verdict + mode policy says drop. Returning None here
+              // means buildCredentialsWithAccessToken will see no entry for
+              // this host and generate a fresh Entra credential. The INFO
+              // log lives in [[isStaleSettingsEntry]] so the user sees
+              // exactly which entry was overridden, with the actionable
+              // remediation if Entra also fails.
+              None
+            } else {
+              getRealm(uri).map { realm =>
+                log.debug(s"creating credentials for realm=$realm, host=$host, user=$user")
+                Credentials(realm, host, user, password)
+              }
             }
           }.getOrElse {
             log.debug("matching <server> not found")
@@ -492,6 +668,143 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       }.flatten
       log.debug(s"created ${credentials.size} credentials from settings.xml")
       credentials
+    }
+
+    // Per-builder cache of probe verdicts, keyed by the FULL feed URI string.
+    // Keying by URI (not just host) is required for correctness: ADO serves
+    // every org and every feed at the same host (`pkgs.dev.azure.com`, or
+    // multiple feeds under `<org>.pkgs.visualstudio.com/<project>/_packaging/`)
+    // so a host-keyed cache would let the first feed's verdict bleed into
+    // every other feed on the same host — silently trusting stale entries
+    // for feed B if feed A's PAT happened to be valid (the bug this PR is
+    // designed to fix), or silently dropping valid entries for feed A if
+    // feed B's PAT happened to be stale. Per-URI keeps the optimization
+    // ("one probe per distinct feed in a multi-module build") while making
+    // the verdict per-credential. ConcurrentHashMap + `computeIfAbsent`
+    // ensures we don't double-probe under concurrent first-touch from
+    // parallel `credentials` task evaluation.
+    private val probeCache =
+      new java.util.concurrent.ConcurrentHashMap[String, java.lang.Boolean]()
+
+    /** Decide whether the settings.xml entry for `(uri, user, password)`
+      * should be dropped (returns `true` = "drop, fall through to Entra")
+      * or trusted (`false`).
+      *
+      * Honors [[ValidateExistingCredentialsProperty]]:
+      *   - `never` → always trust (returns `false` without probing)
+      *   - `always` → probe; drop on 401, trust otherwise
+      *   - `auto` (default) → probe; on 401 try Entra. If Entra works,
+      *     drop. If Entra unreachable, keep the entry but log an INFO line
+      *     telling the user what happened so the eventual 401 isn't a
+      *     mystery.
+      *
+      * Probe results are cached per URI for the builder's lifetime (see
+      * [[probeCache]] doc for why URI and not host).
+      * Non-ADO hosts and resolvers without a host (somehow) are never
+      * probed — trust them. Network errors during the probe are also
+      * trusted (assume transient, don't punish the user). */
+    private[chungmin] def isStaleSettingsEntry(
+        uri: URI, host: String, user: String, password: String): Boolean = {
+      if (mode == ValidateNever) return false
+      if (host == null || !AzureDevOpsCredentialsPlugin.isAzureDevOpsHost(host)) return false
+      // Defense-in-depth: never put PAT/Bearer on a cleartext wire. The TLS
+      // endpoint-identification fix (configureSslEndpointIdentification) only
+      // protects the `if scheme == "https"` branch in headRequest; if the
+      // resolver URI is `http://...`, the `else { rawSocket }` branch
+      // bypasses TLS entirely and Authorization headers would go on the wire
+      // in plaintext. ADO only serves HTTPS, so an `http://pkgs.dev.azure.com`
+      // resolver is almost certainly a typo — but the cost of defending is
+      // one line, and we'd rather trust the entry (legacy v0.0.9 behavior)
+      // than expose credentials. Skipping here keeps the probe path clean
+      // without affecting whatever the user's Aether/sbt fetch eventually
+      // does over the same `http://` URL.
+      if (uri.getScheme != "https") return false
+      probeCache.computeIfAbsent(uri.toString, _ =>
+        java.lang.Boolean.valueOf(probeAndDecide(uri, host, user, password, mode))
+      ).booleanValue()
+    }
+
+    private def probeAndDecide(
+        uri: URI, host: String, user: String, password: String, mode: String): Boolean =
+      probeAndDecideImpl(uri, host, user, password, mode)
+
+    /** Test seam for [[probeAndDecide]]. Production binds to a thin proxy of
+      * the real implementation; tests override this to inject specific probe
+      * outcomes and assert call counts (e.g. cache-hit verification). */
+    protected[chungmin] def probeAndDecideImpl(
+        uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+      val status = probeWithBasic(uri, host, user, password)
+      status match {
+        case Some(401) =>
+          if (mode == ValidateAlways) {
+            log.info(
+              s"$host: settings.xml credentials returned 401; " +
+                "falling through to Entra token acquisition.")
+            true
+          } else {
+            // auto mode. Step 1: can we even acquire an Entra token?
+            getToken() match {
+              case None =>
+                log.info(
+                  s"$host: settings.xml credentials returned 401, but Entra is " +
+                    "also unreachable. Build will likely fail with 401. " +
+                    "Run `az login` or configure AZURE_CLIENT_ID to enable " +
+                    "automatic credential refresh.")
+                false
+              case Some(token) =>
+                // Step 2: does that token actually work against this feed? On
+                // hosts where Managed Identity is available (Azure VMs, App
+                // Service), getToken() succeeds even when AzureCli is
+                // unavailable — but the MI may not have access to the feed
+                // the user's PAT was scoped to. Overriding the user's stale
+                // PAT with a no-access MI token would leave the build still
+                // failing with 401, with a misleading "fell through to Entra"
+                // log line. Verify before override.
+                val entraStatus = probeWithBearer(uri, host, token)
+                if (entraStatus.contains(401)) {
+                  log.info(
+                    s"$host: settings.xml credentials returned 401, AND a fresh " +
+                      "Entra token also returned 401 against this feed. The " +
+                      "Entra identity in scope (Azure CLI / env vars / Managed " +
+                      "Identity) may not have access to this feed. Try `az login` " +
+                      "as a user with feed access, or check role assignments.")
+                  false
+                } else {
+                  log.info(
+                    s"$host: settings.xml credentials returned 401; " +
+                      "falling through to Entra token acquisition.")
+                  true
+                }
+            }
+          }
+        case _ =>
+          // 200 / 404 / network error / unparseable status: trust the entry.
+          // (Most ADO feed roots return 404 to a HEAD with valid Entra
+          // bearer — we cannot distinguish "auth worked" from "feed deleted"
+          // by status alone, so we don't try; this feature's scope is
+          // specifically the stale-credential case.)
+          false
+      }
+    }
+
+    private def probeWithBasic(
+        uri: URI, host: String, user: String, password: String): Option[Int] = {
+      val auth = AzureDevOpsCredentialsPlugin.basicAuthHeader(user, password)
+      try AzureDevOpsCredentialsPlugin.headRequest(uri, Some(auth))._1
+      catch {
+        case NonFatal(e) =>
+          log.debug(s"probe of $host (Basic) failed with $e; trusting existing credentials")
+          None
+      }
+    }
+
+    private def probeWithBearer(uri: URI, host: String, token: String): Option[Int] = {
+      try AzureDevOpsCredentialsPlugin.headRequest(uri, Some(s"Bearer $token"))._1
+      catch {
+        case NonFatal(e) =>
+          log.debug(s"verification probe of $host (Bearer) failed with $e; assuming token works")
+          None
+      }
     }
   }
 

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -679,10 +679,19 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     // for feed B if feed A's PAT happened to be valid (the bug this PR is
     // designed to fix), or silently dropping valid entries for feed A if
     // feed B's PAT happened to be stale. Per-URI keeps the optimization
-    // ("one probe per distinct feed in a multi-module build") while making
-    // the verdict per-credential. ConcurrentHashMap + `computeIfAbsent`
-    // ensures we don't double-probe under concurrent first-touch from
-    // parallel `credentials` task evaluation.
+    // (one probe per distinct feed URI within a single credentials-task
+    // evaluation — i.e. deduping when multiple resolvers in one project
+    // resolve to the same URI, and deduping concurrent first-touch when
+    // sbt evaluates the credentials task in parallel within that project)
+    // while making the verdict per-credential. ConcurrentHashMap +
+    // `computeIfAbsent` provides the concurrent-first-touch atomicity.
+    //
+    // The cache scope is per-builder, and `projectSettings` instantiates
+    // one builder per project's `credentials` task. An N-module sbt build
+    // that shares one feed across all modules will probe N times across
+    // the build (once per module) — sharing the cache across modules
+    // would require build-scope mutable state we deliberately don't
+    // introduce.
     private val probeCache =
       new java.util.concurrent.ConcurrentHashMap[String, java.lang.Boolean]()
 
@@ -730,7 +739,16 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
 
     /** Test seam for [[probeAndDecide]]. Production binds to a thin proxy of
       * the real implementation; tests override this to inject specific probe
-      * outcomes and assert call counts (e.g. cache-hit verification). */
+      * outcomes and assert call counts (e.g. cache-hit verification).
+      *
+      * `mode` is passed explicitly as an argument (not read from the enclosing
+      * builder's `mode` field) so a test can override `probeAndDecideImpl`
+      * and assert decision-tree behaviour against an arbitrary mode without
+      * constructing a new builder per mode. Production's only call site
+      * (in [[isStaleSettingsEntry]]) passes the builder's `mode` field
+      * verbatim — do not collapse the parameter into a `this.mode` read
+      * without removing the test-injection seam, or the indirection silently
+      * stops mattering. */
     protected[chungmin] def probeAndDecideImpl(
         uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
       val status = probeWithBasic(uri, host, user, password)

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -726,13 +726,22 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       * should be dropped (returns `true` = "drop, fall through to Entra")
       * or trusted (`false`).
       *
-      * Honors [[ValidateExistingCredentialsProperty]]:
-      *   - `never` → always trust (returns `false` without probing)
-      *   - `always` → probe; drop on 401, trust otherwise
-      *   - `auto` (default) → probe; on 401 try Entra. If Entra works,
-      *     drop. If Entra unreachable, keep the entry but log an INFO line
-      *     telling the user what happened so the eventual 401 isn't a
-      *     mystery.
+      * Honors the builder's `mode` (resolved at construction from
+      * [[ValidateExistingCredentialsProperty]] OR the build.sbt setting
+      * key [[autoImport.azureDevOpsValidateExistingCredentials]] — the
+      * setting key wins for per-project scoping):
+      *   - `never` → always trust (returns `false` without probing).
+      *   - `always` → probe; drop on 401, trust otherwise.
+      *   - `auto` (default) → probe; on 401 try Entra. If Entra is
+      *     unreachable, keep the entry and log an INFO line with `az
+      *     login` remediation. If Entra IS reachable, re-probe the feed
+      *     with the new token to verify it has feed access:
+      *     Bearer-probe non-401 → drop the entry (Entra path takes over);
+      *     Bearer-probe 401 → keep the entry and log an INFO line about
+      *     Entra-identity feed scope (common on Azure VMs whose Managed
+      *     Identity doesn't cover the user's feed). On a Bearer-probe
+      *     network error, take the optimistic-drop branch (treat as "not
+      *     401") rather than re-stranding the user with their stale PAT.
       *
       * Probe results are cached per URI for the builder's lifetime (see
       * [[probeCache]] doc for why URI and not host).

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -324,6 +324,21 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     else if (uri.getScheme == "https") 443
     else 80
 
+  /** Build the HTTP/1.1 HEAD request line + headers as a single string,
+    * ready to write to the socket. Pure helper (no I/O) so the request
+    * shape is directly unit-testable — verifying via [[headRequest]]
+    * end-to-end would require an actual round-trip, and the auth-on-wire
+    * positive case can't run over plain TCP after the
+    * `https`-required guard on [[headRequest]].
+    *
+    * Format: `HEAD <path> HTTP/1.1\r\nHost: <host>\r\n[Authorization: <auth>\r\n]Connection: close\r\n\r\n`.
+    * The Authorization line is included iff `authHeader` is `Some(...)`. */
+  private[chungmin] def buildHeadRequestLine(
+      host: String, path: String, authHeader: Option[String]): String = {
+    val authLine = authHeader.map(h => s"Authorization: $h\r\n").getOrElse("")
+    s"HEAD $path HTTP/1.1\r\nHost: $host\r\n${authLine}Connection: close\r\n\r\n"
+  }
+
   /** Send a HEAD request with optional credentials and return both the
     * response status code (parsed from the first line) and the response
     * headers.
@@ -336,9 +351,23 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     *
     * The authorization header (if provided) is set exactly once and never
     * re-sent on a redirect (we don't follow them — the response line is
-    * read and returned verbatim). */
+    * read and returned verbatim).
+    *
+    * **Defense-in-depth on cleartext credentials.** When `authHeader` is
+    * `Some(...)` and `uri.getScheme` is not `"https"`, throws
+    * `IllegalArgumentException` before opening the socket — preventing
+    * any future caller (refactor, new probe helper, etc.) from accidentally
+    * writing the Authorization header over a plain-TCP wire. The
+    * `isStaleSettingsEntry` entry-point guard at the call site short-
+    * circuits the same case for the production probe path; this guard is
+    * the second gate, so the comment claim "defense-in-depth" is literally
+    * two gates instead of one. */
   private[chungmin] def headRequest(
       uri: URI, authHeader: Option[String]): (Option[Int], Seq[(String, String)]) = {
+    require(
+      authHeader.isEmpty || uri.getScheme == "https",
+      s"headRequest with an Authorization header requires an https URI; got ${uri.getScheme}://${uri.getHost} " +
+        "(refusing to write credentials over a plain-TCP wire)")
     val host = uri.getHost
     val port = defaultPort(uri)
     val path = Option(uri.getRawPath).filter(_.nonEmpty).getOrElse("/")
@@ -366,9 +395,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       try {
         val writer = new BufferedWriter(
           new OutputStreamWriter(socket.getOutputStream, "UTF-8"))
-        val authLine = authHeader.map(h => s"Authorization: $h\r\n").getOrElse("")
-        writer.write(
-          s"HEAD $path HTTP/1.1\r\nHost: $host\r\n${authLine}Connection: close\r\n\r\n")
+        writer.write(buildHeadRequestLine(host, path, authHeader))
         writer.flush()
         val reader = new BufferedReader(
           new InputStreamReader(socket.getInputStream, "UTF-8"))
@@ -805,7 +832,15 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       }
     }
 
-    private def probeWithBasic(
+    /** Probe `uri` with HTTP Basic auth derived from `user`/`password` and
+      * return the response status. Exposed as a test seam: overriding this
+      * lets a test inject specific Basic-probe outcomes (e.g. 401, 200,
+      * `None` for network error) without driving a real socket through
+      * [[headRequest]] — important because [[headRequest]] now refuses
+      * Authorization headers on non-https URIs, so the easy fake-server
+      * pattern of `http://localhost:$port/` can no longer hit the probe
+      * path end-to-end. */
+    protected[chungmin] def probeWithBasic(
         uri: URI, host: String, user: String, password: String): Option[Int] = {
       val auth = AzureDevOpsCredentialsPlugin.basicAuthHeader(user, password)
       try AzureDevOpsCredentialsPlugin.headRequest(uri, Some(auth))._1
@@ -816,7 +851,9 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       }
     }
 
-    private def probeWithBearer(uri: URI, host: String, token: String): Option[Int] = {
+    /** Probe `uri` with HTTP Bearer auth and return the response status.
+      * Same test-seam rationale as [[probeWithBasic]]. */
+    protected[chungmin] def probeWithBearer(uri: URI, host: String, token: String): Option[Int] = {
       try AzureDevOpsCredentialsPlugin.headRequest(uri, Some(s"Bearer $token"))._1
       catch {
         case NonFatal(e) =>

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -347,11 +347,16 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     * response status code (parsed from the first line) and the response
     * headers.
     *
-    * Uses a raw socket instead of HttpURLConnection to avoid triggering
-    * sbt's global IvyAuthenticator (which logs spurious "Unable to find
-    * credentials" errors on 401) AND to keep the Authorization header
-    * from being logged by Aether/sbt's HTTP transport layer — a
-    * non-trivial PAT-leakage hazard since 0.0.9 added the probe path.
+    * Uses a raw socket instead of HttpURLConnection for two reasons:
+    *
+    *  - To avoid triggering sbt's global IvyAuthenticator (which logs
+    *    spurious "Unable to find credentials" errors on 401) — this
+    *    motivated the original v0.0.9 helper that only sent
+    *    unauthenticated realm-detection probes.
+    *  - To keep the Authorization header from being logged by Aether/sbt's
+    *    HTTP transport layer — a non-trivial PAT-leakage hazard introduced
+    *    in v0.0.10 when this helper started carrying PAT/Bearer credentials
+    *    for the authenticated-probe path.
     *
     * The authorization header (if provided) is set exactly once and never
     * re-sent on a redirect (we don't follow them — the response line is

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -79,15 +79,19 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
     *
     * Values (case-insensitive):
     *
-    *   - `"auto"` (default): probe each entry with a HEAD request; if the
-    *     feed returns 401 AND Entra acquisition succeeds, drop the entry and
-    *     fall through to the Entra path. If Entra is unreachable, keep the
-    *     stale entry and log an INFO line — same outcome as the legacy
-    *     behavior, but with diagnostic signal.
-    *   - `"always"`: probe; on 401, drop unconditionally (Entra's failure
-    *     becomes the user-visible error if it can't acquire either).
+    *   - `"auto"` (default): probe each entry; on a 401, try Entra and
+    *     verify the new token actually has feed access before dropping the
+    *     entry. Falls back to keeping the entry with diagnostic INFO logs
+    *     when Entra is unreachable or the verified token lacks feed scope.
+    *   - `"always"`: probe; on 401, drop unconditionally (no Entra-side
+    *     verification — Entra's eventual failure becomes the user-visible
+    *     error if it can't acquire a working token either).
     *   - `"never"`: legacy behavior — trust settings.xml entries
-    *     unconditionally.
+    *     unconditionally, without probing.
+    *
+    * See [[CredentialsBuilder.isStaleSettingsEntry]] for the full
+    * branch-by-branch decision tree (the central authority on per-branch
+    * behavior; the natural place for future Bearer-verify changes to land).
     *
     * Configurable as `-D` JVM property, in `.jvmopts`, or via `SBT_OPTS`.
     * The `build.sbt` setting [[autoImport.azureDevOpsValidateExistingCredentials]]

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -756,26 +756,31 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       // does over the same `http://` URL.
       if (uri.getScheme != "https") return false
       probeCache.computeIfAbsent(uri.toString, _ =>
-        java.lang.Boolean.valueOf(probeAndDecide(uri, host, user, password, mode))
+        java.lang.Boolean.valueOf(probeAndDecideImpl(uri, host, user, password, mode))
       ).booleanValue()
     }
 
-    private def probeAndDecide(
-        uri: URI, host: String, user: String, password: String, mode: String): Boolean =
-      probeAndDecideImpl(uri, host, user, password, mode)
-
-    /** Test seam for [[probeAndDecide]]. Production binds to a thin proxy of
-      * the real implementation; tests override this to inject specific probe
-      * outcomes and assert call counts (e.g. cache-hit verification).
+    /** Probe `uri` with the supplied `mode` and decide whether the settings
+      * entry is stale. Returns `true` if the entry should be dropped (stale),
+      * `false` if it should be kept (trusted).
       *
-      * `mode` is passed explicitly as an argument (not read from the enclosing
-      * builder's `mode` field) so a test can override `probeAndDecideImpl`
-      * and assert decision-tree behaviour against an arbitrary mode without
-      * constructing a new builder per mode. Production's only call site
-      * (in [[isStaleSettingsEntry]]) passes the builder's `mode` field
-      * verbatim — do not collapse the parameter into a `this.mode` read
-      * without removing the test-injection seam, or the indirection silently
-      * stops mattering. */
+      * Public-but-`protected[chungmin]` is intentional: the suffix `Impl` and
+      * the visibility are the test-injection seam. Tests in
+      * `dev.chungmin.sbt` override this method to inject specific
+      * `(probeWithBasic, probeWithBearer)` outcomes and assert the
+      * decision-tree branches in isolation — for example, `probeAndDecide
+      * (auto, Entra works, Bearer probe ALSO 401)` overrides this with a
+      * canned `false` to bypass the real probe while exercising the
+      * surrounding `isStaleSettingsEntry` flow.
+      *
+      * `mode` is passed explicitly as an argument (not read from the
+      * enclosing builder's `mode` field) so a test override can assert
+      * decision-tree behaviour against an arbitrary mode value without
+      * constructing a separate builder per mode. Production's only call
+      * site (in [[isStaleSettingsEntry]]) passes the builder's `mode`
+      * field verbatim — do not collapse the parameter into a `this.mode`
+      * read without removing the test-injection seam, or the per-call mode
+      * argument silently stops mattering. */
     protected[chungmin] def probeAndDecideImpl(
         uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
       val status = probeWithBasic(uri, host, user, password)

--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -779,9 +779,10 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
       *    (Basic-probe 401 → auto/always fork → Bearer-verify 401 → keep, etc.)
       *    leave `probeAndDecideImpl` intact and instead override
       *    [[probeWithBasic]] / [[probeWithBearer]] (their own Scaladoc explains
-      *    that seam separately). The `isStaleSettingsEntry decision tree`
-      *    tests in `CredentialsBuilderSpec.scala` use this pattern via
-      *    `stubProbeBuilder`.
+      *    that seam separately). The `probeAndDecideImpl` decision-tree tests
+      *    in `CredentialsBuilderSpec.scala` use this pattern via
+      *    `stubProbeBuilder` — both the simple-decision tests (Basic-probe
+      *    only) and the auto-mode Bearer-verify tests live under that label.
       *
       * `mode` is passed explicitly as an argument (not read from the
       * enclosing builder's `mode` field) so a test override of EITHER seam

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -1038,18 +1038,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   // ─── probe cache (per-builder, URI-keyed) ──────────────────────────────
 
-  "isStaleSettingsEntry cache" should "probe at most once per URI per builder" in {
-    withValidationMode(Some("always")) {
-      val b = new ProbeBuilder(Some(401))
-      val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
-      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
-      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
-      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
-      b.probeCalls shouldBe 3 // ProbeBuilder doesn't honor cache, but the REAL impl does — verified by the real-impl test below
-    }
-  }
-
-  it should "actually cache in the real implementation (one probeAndDecide call per URI)" in {
+  "isStaleSettingsEntry cache" should "actually cache in the real implementation (one probeAndDecide call per URI)" in {
     withValidationMode(Some("always")) {
       var calls = 0
       val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -1002,28 +1002,26 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   // (passed into testBuilder) stubs isStaleSettingsEntry wholesale; the real
   // probeAndDecideImpl decision tree has its own dedicated tests below.
   "buildCredentialsFromMavenSettings probe" should
-      "drop the settings entry when the local probe server returns 401 in 'always' mode" in {
-    withValidationMode(Some("always")) {
-      // Need a resolver pointed at a real-but-ADO-shaped host: use a real
-      // ADO URL whose root we don't actually hit (the override below skips
-      // the network). The key is exercising buildCredentialsFromMavenSettings'
-      // new probe branch.
-      val settings = writeSettings(
-        """<?xml version="1.0"?>
-          |<settings><servers><server>
-          |  <id>AzureDevOps</id><username>u</username><password>bad-pat</password>
-          |</server></servers></settings>""".stripMargin)
-      val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
-      // Use testBuilder with a stale function that simulates probe=401-always-drop.
-      val builder = testBuilder(
-        settings = settings,
-        stale = (_, _, _, _) => true)
-      val result = builder.buildCredentials(Seq.empty, Seq(resolver))
-      // The settings entry was dropped, and buildCredentialsWithAccessToken
-      // generated an Entra cred for the host (with userName from URL parsing).
-      val users = result.collect { case c: DirectCredentials => c.userName }
-      users shouldBe Seq("myorg")
-    }
+      "drop the settings entry when stale function returns true" in {
+    // Use a resolver pointed at a real-but-ADO-shaped host so the wiring
+    // accepts it; the override below skips the network. The key is exercising
+    // buildCredentialsFromMavenSettings' new probe branch (which calls
+    // isStaleSettingsEntry unconditionally — mode handling lives inside that
+    // method, so this test does not need to pin a specific validation mode).
+    val settings = writeSettings(
+      """<?xml version="1.0"?>
+        |<settings><servers><server>
+        |  <id>AzureDevOps</id><username>u</username><password>bad-pat</password>
+        |</server></servers></settings>""".stripMargin)
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(
+      settings = settings,
+      stale = (_, _, _, _) => true)
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    // The settings entry was dropped, and buildCredentialsWithAccessToken
+    // generated an Entra cred for the host (with userName from URL parsing).
+    val users = result.collect { case c: DirectCredentials => c.userName }
+    users shouldBe Seq("myorg")
   }
 
   it should "keep the settings entry when stale function returns false" in {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -898,18 +898,16 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       if (tokenAvailable) Some("entra-token") else None
     // Stub the network call: override isStaleSettingsEntry wholesale so the
     // simulated probeStatus drives the decision, no actual headRequest fires.
-    var probeCalls = 0
     override private[chungmin] def isStaleSettingsEntry(
         uri: URI, host: String, user: String, password: String): Boolean = {
       // Re-implement the decision tree inline rather than calling super, so
       // `probeStatus` drives the simulated probe outcome without any real
-      // headRequest / network round-trip — and so `probeCalls` records every
-      // surviving (non-short-circuited) invocation, which the mode/host-gate
-      // tests below assert on directly.
+      // headRequest / network round-trip. Mirrors enough of the production
+      // short-circuit logic (Never/host gates) for the mode/host-gate tests
+      // below to assert the right gating behavior via the return value alone.
       val mode = AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode()
       if (mode == AzureDevOpsCredentialsPlugin.ValidateNever) return false
       if (host == null || !AzureDevOpsCredentialsPlugin.isAzureDevOpsHost(host)) return false
-      probeCalls += 1
       probeStatus match {
         case Some(401) =>
           if (mode == AzureDevOpsCredentialsPlugin.ValidateAlways) true
@@ -1166,18 +1164,6 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       uri, "pkgs.dev.azure.com", "u", "p",
       AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe true
   }
-
-  it should "return true (drop) when probe is 401 + auto + Entra works" in {
-    val builder = stubProbeBuilder(
-      basicStatus = Some(401),
-      bearerStatus = Some(200),  // verify probe says the new token has access
-      tokenValue = "entra")
-    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
-    builder.probeAndDecideImpl(
-      uri, "pkgs.dev.azure.com", "u", "p",
-      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
-  }
-
   it should "return false (keep) when probe is 401 + auto + Entra unreachable" in {
     val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
       override protected def newCredential(): TokenCredential =

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -804,31 +804,65 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  it should "send the Authorization header verbatim when provided" in {
-    // Echo the request back so we can verify the Authorization line is on the wire.
-    val server = new ServerSocket(0)
-    @volatile var received: String = ""
-    try {
-      val port = server.getLocalPort
-      val t = new Thread(() => {
-        try {
-          val client = server.accept()
-          try {
-            val buf = new Array[Byte](2048)
-            val n = client.getInputStream.read(buf)
-            received = new String(buf, 0, n, "UTF-8")
-            val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
-            w.write("HTTP/1.1 401 Unauthorized\r\n\r\n")
-            w.flush()
-          } finally client.close()
-        } catch { case NonFatal(_) => () }
-      })
-      t.setDaemon(true); t.start()
-      val uri = new URI(s"http://localhost:$port/")
+  it should "throw IllegalArgumentException when authHeader is set but scheme is not https (defense-in-depth)" in {
+    // The cleartext-credential guard: future callers that try to send an
+    // Authorization header over a non-https URI must hard-fail, not silently
+    // leak credentials over plain TCP. The production probe path
+    // short-circuits this case earlier via isStaleSettingsEntry's
+    // scheme-check, but the guard here is the second gate — so a future
+    // refactor that introduces a new caller (or removes the entry-point
+    // guard) cannot regress to writing Authorization in cleartext without
+    // tripping this require().
+    val uri = new URI("http://example.com/")
+    val ex = intercept[IllegalArgumentException] {
       AzureDevOpsCredentialsPlugin.headRequest(uri, Some("Basic abcdef"))
-      t.join(5000)
-    } finally server.close()
-    received should include ("Authorization: Basic abcdef\r\n")
+    }
+    ex.getMessage should include ("https")
+  }
+
+  it should "allow Authorization header when scheme is https (require does not fire)" in {
+    // Verifies the require's positive branch: https URI + auth is allowed
+    // through (whether the actual TLS handshake succeeds is irrelevant —
+    // we only care that the require itself does not trip). The connect
+    // is expected to fail (host:port unreachable for the bogus URI), which
+    // is a non-IllegalArgumentException — exactly the contract we want.
+    val uri = new URI("https://localhost:1/")
+    intercept[Exception] {
+      AzureDevOpsCredentialsPlugin.headRequest(uri, Some("Basic abcdef"))
+    } shouldBe a [java.io.IOException]
+  }
+
+  "buildHeadRequestLine" should "produce a HEAD line with Host and the Authorization header when provided" in {
+    val req = AzureDevOpsCredentialsPlugin.buildHeadRequestLine(
+      host = "pkgs.dev.azure.com",
+      path = "/myorg/_packaging/myfeed/maven/v1",
+      authHeader = Some("Basic QWxhZGRpbjpPcGVuU2VzYW1l"))
+    req shouldBe
+      "HEAD /myorg/_packaging/myfeed/maven/v1 HTTP/1.1\r\n" +
+      "Host: pkgs.dev.azure.com\r\n" +
+      "Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l\r\n" +
+      "Connection: close\r\n\r\n"
+  }
+
+  it should "produce a HEAD line WITHOUT the Authorization header when None" in {
+    val req = AzureDevOpsCredentialsPlugin.buildHeadRequestLine(
+      host = "pkgs.dev.azure.com",
+      path = "/",
+      authHeader = None)
+    req shouldBe
+      "HEAD / HTTP/1.1\r\n" +
+      "Host: pkgs.dev.azure.com\r\n" +
+      "Connection: close\r\n\r\n"
+  }
+
+  it should "produce a HEAD line with the Bearer token when provided" in {
+    val req = AzureDevOpsCredentialsPlugin.buildHeadRequestLine(
+      host = "pkgs.dev.azure.com",
+      path = "/myorg/_packaging/myfeed/maven/v1",
+      authHeader = Some("Bearer eyJhbGciOiJSUzI1NiJ9.fake.token"))
+    req should include ("Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.fake.token\r\n")
+    req should startWith ("HEAD /myorg/_packaging/myfeed/maven/v1 HTTP/1.1\r\n")
+    req should endWith ("Connection: close\r\n\r\n")
   }
 
   it should "return None as status when the status line is malformed" in {
@@ -1116,107 +1150,102 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  // ─── probeAndDecide (real network probe via local server) ──────────────
+  // ─── probeAndDecide decision-tree tests ────────────────────────────────
 
-  // These tests exercise the actual probeAndDecide implementation by routing
-  // it at a local server. Because isAzureDevOpsHost filters non-ADO hosts,
-  // we test probeAndDecide directly (rather than through isStaleSettingsEntry).
+  // These exercise probeAndDecideImpl's branching logic directly, using
+  // stubbed probeWithBasic / probeWithBearer values. The headRequest
+  // wire-format and TLS-endpoint-ID invariants are verified by their
+  // dedicated tests above.
 
   "probeAndDecide" should "return false (trust) when network probe returns 200" in {
-    withRawHeadServer("HTTP/1.1 200 OK\r\n\r\n") { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
-    }
+    val builder = stubProbeBuilder(
+      basicStatus = Some(200), bearerStatus = None, tokenValue = "n/a")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
   }
 
   it should "return true (drop) when network probe returns 401 in 'always' mode" in {
-    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe true
-    }
+    val builder = stubProbeBuilder(
+      basicStatus = Some(401), bearerStatus = None, tokenValue = "n/a")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe true
   }
 
   it should "return true (drop) when probe is 401 + auto + Entra works" in {
-    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
-        override protected def newCredential(): TokenCredential = credentialReturning("entra")
-      }
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
-    }
+    val builder = stubProbeBuilder(
+      basicStatus = Some(401),
+      bearerStatus = Some(200),  // verify probe says the new token has access
+      tokenValue = "entra")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
   it should "return false (keep) when probe is 401 + auto + Entra unreachable" in {
-    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
-        override protected def newCredential(): TokenCredential =
-          fakeCredential(Mono.error[AccessToken](new RuntimeException("no az")))
-      }
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      override protected def newCredential(): TokenCredential =
+        fakeCredential(Mono.error[AccessToken](new RuntimeException("no az")))
+      override protected[chungmin] def probeWithBasic(
+          uri: URI, host: String, user: String, password: String): Option[Int] = Some(401)
+      // probeWithBearer is unreachable here (getToken returns None first); leave default
     }
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
   }
 
   it should "return false (trust) when probe throws a network error" in {
-    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
-    val uri = new URI("http://localhost:1/never-routable")  // port 1: nothing listening
+    val builder = stubProbeBuilder(
+      basicStatus = None, bearerStatus = None, tokenValue = "n/a")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
     builder.probeAndDecideImpl(
-      uri, "localhost", "u", "p",
+      uri, "pkgs.dev.azure.com", "u", "p",
       AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
   }
 
   // ─── auto-mode Bearer verification (bug-1 fix: re-probe with Entra token) ───
 
-  /** Local server that serves N canned responses in sequence (one per accepted
-    * connection), so a probeAndDecideImpl call can be observed across BOTH
-    * the initial Basic probe AND the post-acquisition Bearer verification. */
-  private def withSequentialServers(responses: Seq[String])(test: (String, Int) => Unit): Unit = {
-    val server = new ServerSocket(0)
-    try {
-      val port = server.getLocalPort
-      val t = new Thread(() => {
-        try {
-          responses.foreach { resp =>
-            val client = server.accept()
-            try {
-              val buf = new Array[Byte](2048)
-              client.getInputStream.read(buf)
-              val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
-              w.write(resp); w.flush()
-            } finally client.close()
-          }
-        } catch { case NonFatal(_) => () }
-      })
-      t.setDaemon(true); t.start()
-      test("localhost", port)
-      t.join(5000)
-    } finally server.close()
-  }
+  /** Test helper: build a CredentialsBuilder whose probeWithBasic /
+    * probeWithBearer return canned `Option[Int]` values, and whose
+    * newCredential returns a fixed token string. Lets the bug-1 / bug-2
+    * tests assert probeAndDecideImpl's decision tree directly against
+    * specific (Basic-probe, Bearer-probe) outcome combinations, without
+    * driving any actual network round-trip — `headRequest` now refuses
+    * to send Authorization headers over http:// URIs, so the previous
+    * `withSequentialServers + http://localhost:$port/` pattern can no
+    * longer hit the probe path. Stubbing the probe helpers (the boundary
+    * just above `headRequest`) keeps these tests focused on the decision
+    * logic. The `headRequest` wire-format and TLS-endpoint-ID
+    * invariants have their own dedicated tests above. */
+  private def stubProbeBuilder(
+      basicStatus: Option[Int],
+      bearerStatus: Option[Int],
+      tokenValue: String
+  ): AzureDevOpsCredentialsPlugin.CredentialsBuilder =
+    new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+      override protected def newCredential(): TokenCredential = credentialReturning(tokenValue)
+      override protected[chungmin] def probeWithBasic(
+          uri: URI, host: String, user: String, password: String): Option[Int] = basicStatus
+      override protected[chungmin] def probeWithBearer(
+          uri: URI, host: String, token: String): Option[Int] = bearerStatus
+    }
 
   "probeAndDecide (auto, Entra works, Bearer probe succeeds)" should
       "return true (drop entry) when the verification probe doesn't get 401" in {
-    withSequentialServers(Seq(
-      "HTTP/1.1 401 Unauthorized\r\n\r\n",
-      "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
-    )) { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
-        override protected def newCredential(): TokenCredential = credentialReturning("ok-token")
-      }
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
-    }
+    val builder = stubProbeBuilder(
+      basicStatus = Some(401),
+      bearerStatus = Some(200),
+      tokenValue = "ok-token")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
   "probeAndDecide (auto, Entra works, Bearer probe ALSO 401)" should
@@ -1228,38 +1257,32 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     // failing, with a misleading "fell through to Entra" log line. The fix:
     // verify the new token's access first, fall back to keeping the stale
     // entry with a clearer diagnostic.
-    withSequentialServers(Seq(
-      "HTTP/1.1 401 Unauthorized\r\n\r\n",
-      "HTTP/1.1 401 Unauthorized\r\n\r\n"
-    )) { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
-        override protected def newCredential(): TokenCredential =
-          credentialReturning("no-access-token")
-      }
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
-    }
+    val builder = stubProbeBuilder(
+      basicStatus = Some(401),
+      bearerStatus = Some(401),
+      tokenValue = "no-access-token")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
   }
 
   "probeAndDecide (auto, Bearer verify network error)" should
       "assume token works (return true, drop entry) — be optimistic on transient blip" in {
-    // First request answered with 401 (stale Basic probe); the helper server is
-    // single-shot, so the second request (Bearer verify) gets a connect failure.
-    // probeWithBearer catches IOException, returns None; isStaleSettingsEntry
-    // treats None as "not 401" → take the optimistic success branch. This is
-    // a deliberate UX choice: a transient blip on the verify probe shouldn't
-    // re-strand the user with their already-stale PAT.
-    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
-      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
-        override protected def newCredential(): TokenCredential = credentialReturning("token")
-      }
-      val uri = new URI(s"http://$host:$port/")
-      builder.probeAndDecideImpl(
-        uri, host, "u", "p",
-        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
-    }
+    // Basic probe answered with 401 (stale); Bearer-verify fails with a
+    // network error (probeWithBearer catches the IOException and returns
+    // None). probeAndDecideImpl treats None as "not 401" → take the
+    // optimistic success branch. Deliberate UX choice: a transient blip
+    // on the verify probe shouldn't re-strand the user with their already-
+    // stale PAT.
+    val builder = stubProbeBuilder(
+      basicStatus = Some(401),
+      bearerStatus = None,
+      tokenValue = "token")
+    val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+    builder.probeAndDecideImpl(
+      uri, "pkgs.dev.azure.com", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
   // ─── CredentialsBuilder(log, mode) constructor (bug-2 fix) ─────────────

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -881,6 +881,26 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
+  // ─── probeWithBasic / probeWithBearer NonFatal swallow ─────────────────
+  //
+  // The decision-tree tests below override these seams wholesale, so the real
+  // try/catch wrappers around headRequest never fire in those paths. Cover
+  // them directly with an unreachable https URI so the connect throws a
+  // NonFatal IOException → catch returns None → caller treats as "trust the
+  // entry". Mirrors the headRequest-https-unbound-port test above.
+
+  "probeWithBasic" should "swallow NonFatal exceptions from headRequest and return None" in {
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
+    val uri = new URI("https://localhost:1/")
+    builder.probeWithBasic(uri, "localhost", "u", "p") shouldBe None
+  }
+
+  "probeWithBearer" should "swallow NonFatal exceptions from headRequest and return None" in {
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
+    val uri = new URI("https://localhost:1/")
+    builder.probeWithBearer(uri, "localhost", "entra-token") shouldBe None
+  }
+
   // ─── isStaleSettingsEntry (the probe decision matrix) ──────────────────
 
   /** A CredentialsBuilder that lets each test pin individual seams.

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -80,12 +80,20 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   private def testBuilder(
       realm: URI => Option[String] = _ => Some(AdoRealm),
       token: () => Option[String] = () => Some("test-pat"),
-      settings: File = new File("/this/path/does/not/exist")
+      settings: File = new File("/this/path/does/not/exist"),
+      stale: (URI, String, String, String) => Boolean = (_, _, _, _) => false
   ): AzureDevOpsCredentialsPlugin.CredentialsBuilder = {
     new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
       override protected def getRealm(uri: URI): Option[String] = realm(uri)
       override protected def getToken(): Option[String] = token()
       override protected def mavenSettingsFile: File = settings
+      // Default the probe verdict to "not stale" so existing tests preserve
+      // their pre-probe semantics ("settings.xml entries are always trusted")
+      // without depending on JVM-global system properties or actual network
+      // I/O. Probe-specific tests pass an explicit stale function.
+      override private[chungmin] def isStaleSettingsEntry(
+          uri: URI, host: String, user: String, password: String): Boolean =
+        stale(uri, host, user, password)
     }
   }
 
@@ -617,6 +625,67 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
+  // ─── configureSslEndpointIdentification (TLS hostname verification) ────
+
+  "configureSslEndpointIdentification" should
+      "set the SSL endpoint identification algorithm to HTTPS" in {
+    // The JDK default for raw SSLSocket leaves endpointIdentificationAlgorithm
+    // unset (null) → cert-chain validation happens but the server's CN/SAN is
+    // NEVER checked against the URI host. With v0.0.10's authenticated probes
+    // putting PATs and Bearer tokens on the wire, that gap becomes a credential-
+    // leak vector against misissued CAs (DigiNotar-class) + DNS hijack. This
+    // helper opts in to "HTTPS" — the canonical JDK algorithm name — so the
+    // TLS handshake fails when the cert hostname doesn't match. Asserting the
+    // PARAMETER is set (rather than spinning up a self-signed test server) is
+    // sufficient: the JDK enforces the algorithm once we ask for it, and the
+    // production code calls this helper on every TLS socket headRequest opens.
+    val factory = javax.net.ssl.SSLSocketFactory.getDefault
+      .asInstanceOf[javax.net.ssl.SSLSocketFactory]
+    // createSocket() with no args returns an unconnected SSLSocket — sufficient
+    // for parameter inspection without any network or cert plumbing.
+    val socket = factory.createSocket().asInstanceOf[javax.net.ssl.SSLSocket]
+    try {
+      // Pre-condition: the JDK default really is null/unset.
+      // (Sanity-check assertion: if a future JDK changes this default to "HTTPS"
+      // out of the box, this test fires and the maintainer can decide whether
+      // the helper is still load-bearing or has become a tautology.)
+      val defaultAlgo = socket.getSSLParameters.getEndpointIdentificationAlgorithm
+      assert(defaultAlgo == null || defaultAlgo.isEmpty,
+        s"Expected JDK default endpointIdentificationAlgorithm to be null/empty, got '$defaultAlgo'")
+      val configured = AzureDevOpsCredentialsPlugin.configureSslEndpointIdentification(socket)
+      configured.getSSLParameters.getEndpointIdentificationAlgorithm shouldBe "HTTPS"
+      // The helper returns the same socket (no new instance).
+      (configured eq socket) shouldBe true
+    } finally socket.close()
+  }
+
+  it should "fail the TLS handshake when the cert hostname doesn't match the URI host (end-to-end)" in {
+    // Real-network smoke test: connect to a public ADO endpoint via an
+    // explicitly-wrong hostname. The JDK's HTTPS algorithm should detect the
+    // mismatch during the handshake and throw SSLHandshakeException BEFORE
+    // any HTTP bytes (including the Authorization header) reach the wire.
+    //
+    // We pick `wrong.host.badssl.com` — a public test endpoint maintained
+    // by badssl.com that serves a valid cert for `*.badssl.com` (NOT for
+    // `wrong.host.badssl.com`), which is the canonical "hostname mismatch"
+    // scenario for SSL test infrastructure. If this becomes flaky (badssl
+    // could go down), demote to @Slow and rely on the
+    // configureSslEndpointIdentification unit test above to lock in behavior.
+    val uri = new URI("https://wrong.host.badssl.com/")
+    try {
+      AzureDevOpsCredentialsPlugin.headRequestHeaders(uri)
+      fail("Expected SSLHandshakeException on hostname mismatch, got success")
+    } catch {
+      case _: javax.net.ssl.SSLHandshakeException => succeed
+      case e: SSLException if Option(e.getMessage).exists(_.toLowerCase.contains("host")) =>
+        succeed // some JDK variants surface as plain SSLException with a hostname-mismatch message
+      case e: java.io.IOException =>
+        // Network unreachable / DNS resolution failure — don't fail the test
+        // on infrastructure issues. The unit test above still covers behavior.
+        cancel(s"Skipping end-to-end SSL hostname check (network/DNS unreachable): $e")
+    }
+  }
+
   // ─── defaultPort (pure helper — no socket) ──────────────────────────────
 
   "defaultPort" should "return the explicit port when set" in {
@@ -641,5 +710,673 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     // (NOT `shouldBe 21`) documents that this is a fallback, not a
     // scheme-aware lookup.
     AzureDevOpsCredentialsPlugin.defaultPort(new URI("ftp://example.com/")) shouldBe 80
+  }
+
+  // ─── basicAuthHeader (pure helper) ─────────────────────────────────────
+
+  "basicAuthHeader" should "produce Basic <base64(user:pass)>" in {
+    // Aladdin:OpenSesame example from RFC 7617 §2.
+    AzureDevOpsCredentialsPlugin.basicAuthHeader(
+      "Aladdin", "OpenSesame") shouldBe "Basic QWxhZGRpbjpPcGVuU2VzYW1l"
+  }
+
+  it should "handle empty username and password without throwing" in {
+    AzureDevOpsCredentialsPlugin.basicAuthHeader("", "") shouldBe "Basic Og=="
+  }
+
+  // ─── validateExistingCredentialsMode (pure helper) ─────────────────────
+
+  /** Saves the validation-mode property, runs `body`, restores. Pattern
+    * matches the existing AzureIdentityLogProperty save/restore in this file. */
+  private def withValidationMode[A](value: Option[String])(body: => A): A = {
+    val prop = AzureDevOpsCredentialsPlugin.ValidateExistingCredentialsProperty
+    val original = Option(System.getProperty(prop))
+    value match {
+      case Some(v) => System.setProperty(prop, v)
+      case None => System.clearProperty(prop)
+    }
+    try body finally {
+      original match {
+        case Some(v) => System.setProperty(prop, v)
+        case None => System.clearProperty(prop)
+      }
+    }
+  }
+
+  "validateExistingCredentialsMode" should "default to 'auto' when property is unset" in {
+    withValidationMode(None) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateAuto
+    }
+  }
+
+  it should "return 'always' when property is 'always'" in {
+    withValidationMode(Some("always")) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateAlways
+    }
+  }
+
+  it should "return 'never' when property is 'never'" in {
+    withValidationMode(Some("never")) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateNever
+    }
+  }
+
+  it should "fall back to 'auto' for unknown values" in {
+    withValidationMode(Some("garbage")) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateAuto
+    }
+  }
+
+  it should "be case-insensitive" in {
+    withValidationMode(Some("ALWAYS")) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateAlways
+    }
+    withValidationMode(Some("Never")) {
+      AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode() shouldBe
+        AzureDevOpsCredentialsPlugin.ValidateNever
+    }
+  }
+
+  // ─── headRequest (status code parsing — new in 0.0.10) ─────────────────
+
+  "headRequest" should "parse the status code from the response line" in {
+    val response =
+      "HTTP/1.1 401 Unauthorized\r\n" +
+      "WWW-Authenticate: Basic realm=\"r\"\r\n\r\n"
+    withRawHeadServer(response) { (host, port) =>
+      val uri = new URI(s"http://$host:$port/")
+      val (status, headers) = AzureDevOpsCredentialsPlugin.headRequest(uri, None)
+      status shouldBe Some(401)
+      headers should contain ("WWW-Authenticate" -> "Basic realm=\"r\"")
+    }
+  }
+
+  it should "return Some(200) on a successful response" in {
+    withRawHeadServer("HTTP/1.1 200 OK\r\n\r\n") { (host, port) =>
+      val uri = new URI(s"http://$host:$port/")
+      val (status, _) = AzureDevOpsCredentialsPlugin.headRequest(uri, None)
+      status shouldBe Some(200)
+    }
+  }
+
+  it should "send the Authorization header verbatim when provided" in {
+    // Echo the request back so we can verify the Authorization line is on the wire.
+    val server = new ServerSocket(0)
+    @volatile var received: String = ""
+    try {
+      val port = server.getLocalPort
+      val t = new Thread(() => {
+        try {
+          val client = server.accept()
+          try {
+            val buf = new Array[Byte](2048)
+            val n = client.getInputStream.read(buf)
+            received = new String(buf, 0, n, "UTF-8")
+            val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
+            w.write("HTTP/1.1 401 Unauthorized\r\n\r\n")
+            w.flush()
+          } finally client.close()
+        } catch { case NonFatal(_) => () }
+      })
+      t.setDaemon(true); t.start()
+      val uri = new URI(s"http://localhost:$port/")
+      AzureDevOpsCredentialsPlugin.headRequest(uri, Some("Basic abcdef"))
+      t.join(5000)
+    } finally server.close()
+    received should include ("Authorization: Basic abcdef\r\n")
+  }
+
+  it should "return None as status when the status line is malformed" in {
+    withRawHeadServer("MALFORMED\r\n\r\n") { (host, port) =>
+      val uri = new URI(s"http://$host:$port/")
+      val (status, _) = AzureDevOpsCredentialsPlugin.headRequest(uri, None)
+      status shouldBe None
+    }
+  }
+
+  it should "return None as status when the status line has no parseable number" in {
+    withRawHeadServer("HTTP/1.1 NOT-A-NUMBER\r\n\r\n") { (host, port) =>
+      val uri = new URI(s"http://$host:$port/")
+      val (status, _) = AzureDevOpsCredentialsPlugin.headRequest(uri, None)
+      status shouldBe None
+    }
+  }
+
+  // ─── isStaleSettingsEntry (the probe decision matrix) ──────────────────
+
+  /** A CredentialsBuilder that lets each test pin individual seams.
+    *
+    * - `probeStatus` controls what headRequest "returns" (we inject by
+    *   overriding probeAndDecide-adjacent state via getToken + a fake
+    *   headRequest stub installed at construction).
+    * - `tokenAvailable` controls whether getToken() returns Some/None,
+    *   exercising the auto-mode fork. */
+  private class ProbeBuilder(
+      probeStatus: Option[Int],
+      tokenAvailable: Boolean = true
+  ) extends AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+    override protected def getToken(): Option[String] =
+      if (tokenAvailable) Some("entra-token") else None
+    // Stub the network call: override probeAndDecide via the helper that
+    // its only call site (isStaleSettingsEntry) consults.
+    var probeCalls = 0
+    override private[chungmin] def isStaleSettingsEntry(
+        uri: URI, host: String, user: String, password: String): Boolean = {
+      // Call the real implementation, but intercept the network probe by
+      // routing through a test-only headRequest stub that returns probeStatus.
+      val mode = AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode()
+      if (mode == AzureDevOpsCredentialsPlugin.ValidateNever) return false
+      if (host == null || !AzureDevOpsCredentialsPlugin.isAzureDevOpsHost(host)) return false
+      probeCalls += 1
+      probeStatus match {
+        case Some(401) =>
+          if (mode == AzureDevOpsCredentialsPlugin.ValidateAlways) true
+          else getToken().isDefined
+        case _ => false
+      }
+    }
+  }
+
+  "isStaleSettingsEntry" should "trust unconditionally in 'never' mode" in {
+    withValidationMode(Some("never")) {
+      val b = new ProbeBuilder(Some(401))
+      b.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  it should "trust unconditionally for non-ADO hosts" in {
+    withValidationMode(Some("always")) {
+      val b = new ProbeBuilder(Some(401))
+      b.isStaleSettingsEntry(
+        new URI("https://repo1.maven.org/maven2/"),
+        "repo1.maven.org", "u", "p") shouldBe false
+    }
+  }
+
+  it should "trust unconditionally when host is null" in {
+    withValidationMode(Some("always")) {
+      val b = new ProbeBuilder(Some(401))
+      b.isStaleSettingsEntry(
+        new URI("file:///somewhere"), null, "u", "p") shouldBe false
+    }
+  }
+
+  it should "drop on 401 in 'always' mode" in {
+    withValidationMode(Some("always")) {
+      val b = new ProbeBuilder(Some(401))
+      b.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe true
+    }
+  }
+
+  it should "drop on 401 in 'auto' mode when Entra is reachable" in {
+    withValidationMode(Some("auto")) {
+      val b = new ProbeBuilder(Some(401), tokenAvailable = true)
+      b.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe true
+    }
+  }
+
+  it should "keep on 401 in 'auto' mode when Entra is unreachable" in {
+    withValidationMode(Some("auto")) {
+      val b = new ProbeBuilder(Some(401), tokenAvailable = false)
+      b.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  it should "trust on non-401 (200, 404, etc.)" in {
+    withValidationMode(Some("always")) {
+      val b200 = new ProbeBuilder(Some(200))
+      b200.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+      val b404 = new ProbeBuilder(Some(404))
+      b404.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  it should "trust on network error (status = None)" in {
+    withValidationMode(Some("always")) {
+      val b = new ProbeBuilder(None)
+      b.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  // ─── probeAndDecide via the real implementation (end-to-end) ───────────
+
+  // The ProbeBuilder above stubs out the network probe to make the decision
+  // tree directly assertable. This test exercises the REAL probeAndDecide
+  // through buildCredentialsFromMavenSettings + a local socket server, so
+  // a future refactor of the real implementation that breaks the decision
+  // tree shows up here (rather than only in integration tests).
+  "buildCredentialsFromMavenSettings probe" should
+      "drop the settings entry when the local probe server returns 401 in 'always' mode" in {
+    withValidationMode(Some("always")) {
+      // Need a resolver pointed at a real-but-ADO-shaped host: use a real
+      // ADO URL whose root we don't actually hit (the override below skips
+      // the network). The key is exercising buildCredentialsFromMavenSettings'
+      // new probe branch.
+      val settings = writeSettings(
+        """<?xml version="1.0"?>
+          |<settings><servers><server>
+          |  <id>AzureDevOps</id><username>u</username><password>bad-pat</password>
+          |</server></servers></settings>""".stripMargin)
+      val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+      // Use testBuilder with a stale function that simulates probe=401-always-drop.
+      val builder = testBuilder(
+        settings = settings,
+        stale = (_, _, _, _) => true)
+      val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+      // The settings entry was dropped, and buildCredentialsWithAccessToken
+      // generated an Entra cred for the host (with userName from URL parsing).
+      val users = result.collect { case c: DirectCredentials => c.userName }
+      users shouldBe Seq("myorg")
+    }
+  }
+
+  it should "keep the settings entry when stale function returns false" in {
+    val settings = writeSettings(
+      """<?xml version="1.0"?>
+        |<settings><servers><server>
+        |  <id>AzureDevOps</id><username>preserved</username><password>p</password>
+        |</server></servers></settings>""".stripMargin)
+    val resolver = MavenRepository("AzureDevOps", AdoFeedUrl)
+    val builder = testBuilder(settings = settings)  // stale defaults to false
+    val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+    val users = result.collect { case c: DirectCredentials => c.userName }
+    users shouldBe Seq("preserved")
+  }
+
+  // ─── probe cache (per-builder, host-keyed) ─────────────────────────────
+
+  "isStaleSettingsEntry cache" should "probe at most once per host per builder" in {
+    withValidationMode(Some("always")) {
+      val b = new ProbeBuilder(Some(401))
+      val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      b.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      b.probeCalls shouldBe 3 // ProbeBuilder doesn't honor cache, but the REAL impl does — verified by the real-impl test below
+    }
+  }
+
+  it should "actually cache in the real implementation (one probeAndDecide call per host)" in {
+    withValidationMode(Some("always")) {
+      var calls = 0
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+          calls += 1
+          true
+        }
+      }
+      val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
+      builder.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      builder.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      builder.isStaleSettingsEntry(uri, "pkgs.dev.azure.com", "u", "p") shouldBe true
+      calls shouldBe 1
+    }
+  }
+
+  // ─── Real isStaleSettingsEntry mode + host filtering ───────────────────
+
+  // ProbeBuilder above stubs out the entire isStaleSettingsEntry method, so
+  // it doesn't exercise the production decision tree's mode/host gates. These
+  // tests use the production CredentialsBuilder (only stubbing probeAndDecideImpl)
+  // so the mode == never / host == null / host non-ADO branches are covered.
+
+  "real isStaleSettingsEntry" should "short-circuit to false in 'never' mode without probing" in {
+    withValidationMode(Some("never")) {
+      var calls = 0
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+          calls += 1
+          true
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+      calls shouldBe 0
+    }
+  }
+
+  it should "short-circuit to false when host is null without probing" in {
+    withValidationMode(Some("always")) {
+      var calls = 0
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+          calls += 1
+          true
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("file:///somewhere"), null, "u", "p") shouldBe false
+      calls shouldBe 0
+    }
+  }
+
+  it should "short-circuit to false for non-ADO hosts without probing" in {
+    withValidationMode(Some("always")) {
+      var calls = 0
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+          calls += 1
+          true
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("https://repo1.maven.org/maven2/"),
+        "repo1.maven.org", "u", "p") shouldBe false
+      calls shouldBe 0
+    }
+  }
+
+  it should "short-circuit to false for http:// URIs without probing (no cleartext credentials)" in {
+    // R6 fix: even when the host passes isAzureDevOpsHost (user typed the right
+    // ADO hostname), an http:// scheme would cause headRequest to use a plain
+    // TCP socket and put the Authorization header on the wire in cleartext.
+    // Same vulnerability class as R5's TLS endpoint-ID gap (cleartext
+    // credentials) but a distinct codepath the R5 fix didn't cover — that fix
+    // only enables hostname verification GIVEN TLS, not the case of no TLS at
+    // all. Trust-the-entry (return false) is the right default for the
+    // misconfigured-resolver case: preserves legacy v0.0.9 behavior and
+    // guarantees no credentials reach a cleartext wire from the probe path.
+    withValidationMode(Some("always")) {
+      var calls = 0
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, mode: String): Boolean = {
+          calls += 1
+          true
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("http://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+      calls shouldBe 0
+    }
+  }
+
+  // ─── probeAndDecide (real network probe via local server) ──────────────
+
+  // These tests exercise the actual probeAndDecide implementation by routing
+  // it at a local server. Because isAzureDevOpsHost filters non-ADO hosts,
+  // we test probeAndDecide directly (rather than through isStaleSettingsEntry).
+
+  "probeAndDecide" should "return false (trust) when network probe returns 200" in {
+    withRawHeadServer("HTTP/1.1 200 OK\r\n\r\n") { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
+    }
+  }
+
+  it should "return true (drop) when network probe returns 401 in 'always' mode" in {
+    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe true
+    }
+  }
+
+  it should "return true (drop) when probe is 401 + auto + Entra works" in {
+    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected def newCredential(): TokenCredential = credentialReturning("entra")
+      }
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
+    }
+  }
+
+  it should "return false (keep) when probe is 401 + auto + Entra unreachable" in {
+    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected def newCredential(): TokenCredential =
+          fakeCredential(Mono.error[AccessToken](new RuntimeException("no az")))
+      }
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
+    }
+  }
+
+  it should "return false (trust) when probe throws a network error" in {
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog)
+    val uri = new URI("http://localhost:1/never-routable")  // port 1: nothing listening
+    builder.probeAndDecideImpl(
+      uri, "localhost", "u", "p",
+      AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
+  }
+
+  // ─── auto-mode Bearer verification (bug-1 fix: re-probe with Entra token) ───
+
+  /** Local server that serves N canned responses in sequence (one per accepted
+    * connection), so a probeAndDecideImpl call can be observed across BOTH
+    * the initial Basic probe AND the post-acquisition Bearer verification. */
+  private def withSequentialServers(responses: Seq[String])(test: (String, Int) => Unit): Unit = {
+    val server = new ServerSocket(0)
+    try {
+      val port = server.getLocalPort
+      val t = new Thread(() => {
+        try {
+          responses.foreach { resp =>
+            val client = server.accept()
+            try {
+              val buf = new Array[Byte](2048)
+              client.getInputStream.read(buf)
+              val w = new BufferedWriter(new OutputStreamWriter(client.getOutputStream, "UTF-8"))
+              w.write(resp); w.flush()
+            } finally client.close()
+          }
+        } catch { case NonFatal(_) => () }
+      })
+      t.setDaemon(true); t.start()
+      test("localhost", port)
+      t.join(5000)
+    } finally server.close()
+  }
+
+  "probeAndDecide (auto, Entra works, Bearer probe succeeds)" should
+      "return true (drop entry) when the verification probe doesn't get 401" in {
+    withSequentialServers(Seq(
+      "HTTP/1.1 401 Unauthorized\r\n\r\n",
+      "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+    )) { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected def newCredential(): TokenCredential = credentialReturning("ok-token")
+      }
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
+    }
+  }
+
+  "probeAndDecide (auto, Entra works, Bearer probe ALSO 401)" should
+      "return false (keep entry) — the Entra identity has no feed access" in {
+    // The bug-1 scenario: stale PAT → 401 on Basic probe; getToken() succeeds
+    // via (say) Managed Identity on an Azure VM; but the MI has no access to
+    // the user's feed, so Bearer-probe with the new token ALSO returns 401.
+    // Overriding the user's PAT with that token would leave the build still
+    // failing, with a misleading "fell through to Entra" log line. The fix:
+    // verify the new token's access first, fall back to keeping the stale
+    // entry with a clearer diagnostic.
+    withSequentialServers(Seq(
+      "HTTP/1.1 401 Unauthorized\r\n\r\n",
+      "HTTP/1.1 401 Unauthorized\r\n\r\n"
+    )) { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected def newCredential(): TokenCredential =
+          credentialReturning("no-access-token")
+      }
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
+    }
+  }
+
+  "probeAndDecide (auto, Bearer verify network error)" should
+      "assume token works (return true, drop entry) — be optimistic on transient blip" in {
+    // First request answered with 401 (stale Basic probe); the helper server is
+    // single-shot, so the second request (Bearer verify) gets a connect failure.
+    // probeWithBearer catches IOException, returns None; isStaleSettingsEntry
+    // treats None as "not 401" → take the optimistic success branch. This is
+    // a deliberate UX choice: a transient blip on the verify probe shouldn't
+    // re-strand the user with their already-stale PAT.
+    withRawHeadServer("HTTP/1.1 401 Unauthorized\r\n\r\n") { (host, port) =>
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected def newCredential(): TokenCredential = credentialReturning("token")
+      }
+      val uri = new URI(s"http://$host:$port/")
+      builder.probeAndDecideImpl(
+        uri, host, "u", "p",
+        AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
+    }
+  }
+
+  // ─── CredentialsBuilder(log, mode) constructor (bug-2 fix) ─────────────
+
+  "CredentialsBuilder(log, mode)" should
+      "use the passed-in mode regardless of -D system property (per-project scoping)" in {
+    // Pin system property to "never"; build with mode="always". The probe
+    // must fire (per the always mode) regardless of the property.
+    withValidationMode(Some("never")) {
+      val settings = writeSettings(
+        """<?xml version="1.0"?>
+          |<settings><servers><server>
+          |  <id>R</id><username>u</username><password>p</password>
+          |</server></servers></settings>""".stripMargin)
+      val resolver = MavenRepository("R", AdoFeedUrl)
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog, "always") {
+        override protected def mavenSettingsFile: File = settings
+        override protected def getRealm(uri: URI): Option[String] = Some(AdoRealm)
+        override protected def getToken(): Option[String] = Some("t")
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, m: String): Boolean = {
+          m shouldBe AzureDevOpsCredentialsPlugin.ValidateAlways
+          true
+        }
+      }
+      val result = builder.buildCredentials(Seq.empty, Seq(resolver))
+      val users = result.collect { case c: DirectCredentials => c.userName }
+      users shouldBe Seq("myorg")  // Entra-generated, not "u" from settings
+    }
+  }
+
+  it should "fall back to the legacy single-arg overload reading the system property" in {
+    withValidationMode(Some("never")) {
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, m: String): Boolean = {
+          fail(s"probeAndDecideImpl should NOT be called in 'never' mode; got $m")
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  it should "normalize mode case-insensitively when passed in directly (regression guard)" in {
+    // Bug: prior to the R1 fix, `CredentialsBuilder(log, "NEVER")` would compare
+    // raw "NEVER" against the lowercase ValidateNever constant, fail equality,
+    // and silently fall into the auto branch — defeating users who set
+    // `-Ddev.chungmin.azure.validateExistingCredentials=NEVER` (a common shell
+    // habit) or `azureDevOpsValidateExistingCredentials := "Never"` in build.sbt.
+    withValidationMode(None) {
+      // Use "NEVER" upper-case via the 2-arg ctor; assert it short-circuits
+      // (never-mode skips probing entirely, so probeAndDecideImpl would not
+      // fire — which the override below FAILs the test if it does).
+      val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog, "NEVER") {
+        override protected[chungmin] def probeAndDecideImpl(
+            uri: URI, host: String, user: String, password: String, m: String): Boolean = {
+          fail(s"raw 'NEVER' must be normalized to ValidateNever and short-circuit; got $m")
+        }
+      }
+      builder.isStaleSettingsEntry(
+        new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+        "pkgs.dev.azure.com", "u", "p") shouldBe false
+    }
+  }
+
+  it should "normalize unknown mode values to auto" in {
+    // Same regression family: a typo like `"alway"` should fall through to
+    // auto, not crash and not pin some other unintended branch.
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog, "alway") {
+      override protected[chungmin] def probeAndDecideImpl(
+          uri: URI, host: String, user: String, password: String, m: String): Boolean = {
+        m shouldBe AzureDevOpsCredentialsPlugin.ValidateAuto
+        false
+      }
+    }
+    builder.isStaleSettingsEntry(
+      new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1"),
+      "pkgs.dev.azure.com", "u", "p") shouldBe false
+  }
+
+  // ─── probe cache key (R1 finding: host-keyed cache collides across feeds) ──
+
+  "isStaleSettingsEntry cache" should
+      "probe distinct feeds on the same host INDEPENDENTLY (not host-keyed)" in {
+    // R1 bug: keying the cache by host alone meant two ADO feeds on the same
+    // host (e.g. `<org>.pkgs.visualstudio.com/A365/_packaging/FeedA/...` vs
+    // `<org>.pkgs.visualstudio.com/A365/_packaging/FeedB/...`, or two orgs on
+    // `pkgs.dev.azure.com`) would inherit each other's verdicts — silently
+    // trusting a stale entry for FeedB if FeedA's PAT was valid (defeats the
+    // PR), or silently dropping a valid entry for FeedA if FeedB's PAT was
+    // stale (defeats user intent). Fix keyed cache by URI string.
+    var probesByUri = Map.empty[String, Int]
+    val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog, "always") {
+      override protected[chungmin] def probeAndDecideImpl(
+          uri: URI, host: String, user: String, password: String, m: String): Boolean = {
+        probesByUri = probesByUri.updated(
+          uri.toString, probesByUri.getOrElse(uri.toString, 0) + 1)
+        // Return different verdicts for different URIs to make the bug
+        // observable: if cache were host-keyed, the second call would see
+        // the cached verdict from the first.
+        if (uri.toString.endsWith("/FeedA/maven/v1")) true else false
+      }
+    }
+    val feedA = new URI("https://pkgs.dev.azure.com/myorg/myproject/_packaging/FeedA/maven/v1")
+    val feedB = new URI("https://pkgs.dev.azure.com/myorg/myproject/_packaging/FeedB/maven/v1")
+    val host = "pkgs.dev.azure.com"
+    builder.isStaleSettingsEntry(feedA, host, "u", "p") shouldBe true
+    builder.isStaleSettingsEntry(feedB, host, "u", "p") shouldBe false
+    // Both URIs must have been probed (one each), not collapsed to one probe
+    // on the shared host.
+    probesByUri.values.toSeq.sorted shouldBe Seq(1, 1)
+    probesByUri.size shouldBe 2
+    // Re-probe each URI: cache MUST hit on second call (still 1 probe per URI).
+    builder.isStaleSettingsEntry(feedA, host, "u", "p") shouldBe true
+    builder.isStaleSettingsEntry(feedB, host, "u", "p") shouldBe false
+    probesByUri.values.toSeq.sorted shouldBe Seq(1, 1)
   }
 }

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -1002,9 +1002,9 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     users shouldBe Seq("preserved")
   }
 
-  // ─── probe cache (per-builder, host-keyed) ─────────────────────────────
+  // ─── probe cache (per-builder, URI-keyed) ──────────────────────────────
 
-  "isStaleSettingsEntry cache" should "probe at most once per host per builder" in {
+  "isStaleSettingsEntry cache" should "probe at most once per URI per builder" in {
     withValidationMode(Some("always")) {
       val b = new ProbeBuilder(Some(401))
       val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
@@ -1015,7 +1015,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  it should "actually cache in the real implementation (one probeAndDecide call per host)" in {
+  it should "actually cache in the real implementation (one probeAndDecide call per URI)" in {
     withValidationMode(Some("always")) {
       var calls = 0
       val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -901,8 +901,11 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     var probeCalls = 0
     override private[chungmin] def isStaleSettingsEntry(
         uri: URI, host: String, user: String, password: String): Boolean = {
-      // Call the real implementation, but intercept the network probe by
-      // routing through a test-only headRequest stub that returns probeStatus.
+      // Re-implement the decision tree inline rather than calling super, so
+      // `probeStatus` drives the simulated probe outcome without any real
+      // headRequest / network round-trip — and so `probeCalls` records every
+      // surviving (non-short-circuited) invocation, which the mode/host-gate
+      // tests below assert on directly.
       val mode = AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode()
       if (mode == AzureDevOpsCredentialsPlugin.ValidateNever) return false
       if (host == null || !AzureDevOpsCredentialsPlugin.isAzureDevOpsHost(host)) return false
@@ -991,13 +994,13 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  // ─── probeAndDecideImpl via the real implementation (end-to-end) ───────
+  // ─── buildCredentialsFromMavenSettings probe wiring ────────────────────
 
-  // The ProbeBuilder above stubs out the network probe to make the decision
-  // tree directly assertable. This test exercises the REAL probeAndDecideImpl
-  // through buildCredentialsFromMavenSettings + a local socket server, so
-  // a future refactor of the real implementation that breaks the decision
-  // tree shows up here (rather than only in integration tests).
+  // These tests exercise the wiring that consults isStaleSettingsEntry from
+  // inside buildCredentialsFromMavenSettings — verifying that a stale verdict
+  // drops the entry and a fresh verdict keeps it. The `stale` callback here
+  // (passed into testBuilder) stubs isStaleSettingsEntry wholesale; the real
+  // probeAndDecideImpl decision tree has its own dedicated tests below.
   "buildCredentialsFromMavenSettings probe" should
       "drop the settings entry when the local probe server returns 401 in 'always' mode" in {
     withValidationMode(Some("always")) {
@@ -1225,7 +1228,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
           uri: URI, host: String, token: String): Option[Int] = bearerStatus
     }
 
-  "isStaleSettingsEntry decision tree (auto, Entra works, Bearer probe succeeds)" should
+  "probeAndDecideImpl (auto, Entra works, Bearer probe succeeds)" should
       "return true (drop entry) when the verification probe doesn't get 401" in {
     val builder = stubProbeBuilder(
       basicStatus = Some(401),
@@ -1237,7 +1240,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
-  "isStaleSettingsEntry decision tree (auto, Entra works, Bearer probe ALSO 401)" should
+  "probeAndDecideImpl (auto, Entra works, Bearer probe ALSO 401)" should
       "return false (keep entry) — the Entra identity has no feed access" in {
     // The bug-1 scenario: stale PAT → 401 on Basic probe; getToken() succeeds
     // via (say) Managed Identity on an Azure VM; but the MI has no access to
@@ -1256,7 +1259,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
   }
 
-  "isStaleSettingsEntry decision tree (auto, Bearer verify network error)" should
+  "probeAndDecideImpl (auto, Bearer verify network error)" should
       "assume token works (return true, drop entry) — be optimistic on transient blip" in {
     // Basic probe answered with 401 (stale); Bearer-verify fails with a
     // network error (probeWithBearer catches the IOException and returns

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -1117,15 +1117,15 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   }
 
   it should "short-circuit to false for http:// URIs without probing (no cleartext credentials)" in {
-    // R6 fix: even when the host passes isAzureDevOpsHost (user typed the right
+    // Even when the host passes isAzureDevOpsHost (user typed the right
     // ADO hostname), an http:// scheme would cause headRequest to use a plain
     // TCP socket and put the Authorization header on the wire in cleartext.
-    // Same vulnerability class as R5's TLS endpoint-ID gap (cleartext
-    // credentials) but a distinct codepath the R5 fix didn't cover — that fix
-    // only enables hostname verification GIVEN TLS, not the case of no TLS at
-    // all. Trust-the-entry (return false) is the right default for the
-    // misconfigured-resolver case: preserves legacy v0.0.9 behavior and
-    // guarantees no credentials reach a cleartext wire from the probe path.
+    // Same vulnerability class as a missing TLS endpoint-ID check
+    // (credentials leaking via insecure transport) but a distinct codepath:
+    // TLS endpoint-ID verification only protects you GIVEN TLS, not the case
+    // of no TLS at all. Trust-the-entry (return false) is the right default
+    // for the misconfigured-resolver case: preserves legacy v0.0.9 behavior
+    // and guarantees no credentials reach a cleartext wire from the probe path.
     withValidationMode(Some("always")) {
       var calls = 0
       val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
@@ -1190,14 +1190,14 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe false
   }
 
-  // ─── auto-mode Bearer verification (bug-1 fix: re-probe with Entra token) ───
+  // ─── auto-mode Bearer verification: re-probe with the new Entra token ─────
 
   /** Test helper: build a CredentialsBuilder whose probeWithBasic /
     * probeWithBearer return canned `Option[Int]` values, and whose
     * newCredential returns a fixed token string. Lets the
     * `probeAndDecideImpl` decision-tree tests — both the simple-decision
     * cases (Basic-probe only: 200, 401-always, network error) and the
-    * bug-1 auto-mode Bearer-verify cases (Basic 401 → re-probe with Entra
+    * auto-mode Bearer-verify cases (Basic 401 → re-probe with Entra
     * token: Bearer 200 / Bearer 401 / Bearer network error) — assert the
     * decision logic directly against specific (Basic-probe, Bearer-probe)
     * outcome combinations, without driving any actual network round-trip.
@@ -1207,8 +1207,8 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     * (the boundary just above `headRequest`) keeps these tests focused on
     * the decision logic. The `headRequest` wire-format and TLS-endpoint-ID
     * invariants have their own dedicated tests above. Not used by the
-    * bug-2 (CredentialsBuilder(log, mode) constructor) tests — those
-    * exercise the mode-injection path, not the probe decision tree. */
+    * `CredentialsBuilder(log, mode)` constructor tests — those exercise
+    * the mode-injection path, not the probe decision tree. */
   private def stubProbeBuilder(
       basicStatus: Option[Int],
       bearerStatus: Option[Int],
@@ -1236,7 +1236,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   "probeAndDecideImpl (auto, Entra works, Bearer probe ALSO 401)" should
       "return false (keep entry) — the Entra identity has no feed access" in {
-    // The bug-1 scenario: stale PAT → 401 on Basic probe; getToken() succeeds
+    // The Entra-identity-lacks-feed-access scenario: stale PAT → 401 on Basic probe; getToken() succeeds
     // via (say) Managed Identity on an Azure VM; but the MI has no access to
     // the user's feed, so Bearer-probe with the new token ALSO returns 401.
     // Overriding the user's PAT with that token would leave the build still
@@ -1271,7 +1271,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
-  // ─── CredentialsBuilder(log, mode) constructor (bug-2 fix) ─────────────
+  // ─── CredentialsBuilder(log, mode) constructor: per-project mode injection ──
 
   "CredentialsBuilder(log, mode)" should
       "use the passed-in mode regardless of -D system property (per-project scoping)" in {
@@ -1315,7 +1315,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   }
 
   it should "normalize mode case-insensitively when passed in directly (regression guard)" in {
-    // Bug: prior to the R1 fix, `CredentialsBuilder(log, "NEVER")` would compare
+    // Without case-insensitive normalization, `CredentialsBuilder(log, "NEVER")` would compare
     // raw "NEVER" against the lowercase ValidateNever constant, fail equality,
     // and silently fall into the auto branch — defeating users who set
     // `-Ddev.chungmin.azure.validateExistingCredentials=NEVER` (a common shell
@@ -1351,11 +1351,11 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       "pkgs.dev.azure.com", "u", "p") shouldBe false
   }
 
-  // ─── probe cache key (R1 finding: host-keyed cache collides across feeds) ──
+  // ─── probe cache key: per-feed-URI (host-keyed would collide across feeds) ──
 
   "isStaleSettingsEntry cache" should
       "probe distinct feeds on the same host INDEPENDENTLY (not host-keyed)" in {
-    // R1 bug: keying the cache by host alone meant two ADO feeds on the same
+    // Bug class: keying the cache by host alone would let two ADO feeds on the same
     // host (e.g. `<org>.pkgs.visualstudio.com/A365/_packaging/FeedA/...` vs
     // `<org>.pkgs.visualstudio.com/A365/_packaging/FeedB/...`, or two orgs on
     // `pkgs.dev.azure.com`) would inherit each other's verdicts — silently

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -903,8 +903,10 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       // Re-implement the decision tree inline rather than calling super, so
       // `probeStatus` drives the simulated probe outcome without any real
       // headRequest / network round-trip. Mirrors enough of the production
-      // short-circuit logic (Never/host gates) for the mode/host-gate tests
-      // below to assert the right gating behavior via the return value alone.
+      // short-circuit logic (Never/host gates) for the tests below to
+      // exercise both the gate-level short-circuits (never mode, non-ADO
+      // host, null host) and the inner decision tree (Basic-probe 200/401,
+      // auto+token availability, network error) via the return value alone.
       val mode = AzureDevOpsCredentialsPlugin.validateExistingCredentialsMode()
       if (mode == AzureDevOpsCredentialsPlugin.ValidateNever) return false
       if (host == null || !AzureDevOpsCredentialsPlugin.isAzureDevOpsHost(host)) return false
@@ -1164,6 +1166,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       uri, "pkgs.dev.azure.com", "u", "p",
       AzureDevOpsCredentialsPlugin.ValidateAlways) shouldBe true
   }
+
   it should "return false (keep) when probe is 401 + auto + Entra unreachable" in {
     val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
       override protected def newCredential(): TokenCredential =
@@ -1191,16 +1194,21 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   /** Test helper: build a CredentialsBuilder whose probeWithBasic /
     * probeWithBearer return canned `Option[Int]` values, and whose
-    * newCredential returns a fixed token string. Lets the bug-1 / bug-2
-    * tests assert probeAndDecideImpl's decision tree directly against
-    * specific (Basic-probe, Bearer-probe) outcome combinations, without
-    * driving any actual network round-trip — `headRequest` now refuses
-    * to send Authorization headers over http:// URIs, so the previous
-    * `withSequentialServers + http://localhost:$port/` pattern can no
-    * longer hit the probe path. Stubbing the probe helpers (the boundary
-    * just above `headRequest`) keeps these tests focused on the decision
-    * logic. The `headRequest` wire-format and TLS-endpoint-ID
-    * invariants have their own dedicated tests above. */
+    * newCredential returns a fixed token string. Lets the
+    * `probeAndDecideImpl` decision-tree tests — both the simple-decision
+    * cases (Basic-probe only: 200, 401-always, network error) and the
+    * bug-1 auto-mode Bearer-verify cases (Basic 401 → re-probe with Entra
+    * token: Bearer 200 / Bearer 401 / Bearer network error) — assert the
+    * decision logic directly against specific (Basic-probe, Bearer-probe)
+    * outcome combinations, without driving any actual network round-trip.
+    * `headRequest` now refuses to send Authorization headers over http://
+    * URIs, so the previous `withSequentialServers + http://localhost:$port/`
+    * pattern can no longer hit the probe path; stubbing the probe helpers
+    * (the boundary just above `headRequest`) keeps these tests focused on
+    * the decision logic. The `headRequest` wire-format and TLS-endpoint-ID
+    * invariants have their own dedicated tests above. Not used by the
+    * bug-2 (CredentialsBuilder(log, mode) constructor) tests — those
+    * exercise the mode-injection path, not the probe decision tree. */
   private def stubProbeBuilder(
       basicStatus: Option[Int],
       bearerStatus: Option[Int],

--- a/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
+++ b/src/test/scala/dev/chungmin/sbt/CredentialsBuilderSpec.scala
@@ -885,10 +885,10 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   /** A CredentialsBuilder that lets each test pin individual seams.
     *
-    * - `probeStatus` controls what headRequest "returns" (we inject by
-    *   overriding probeAndDecide-adjacent state via getToken + a fake
-    *   headRequest stub installed at construction).
-    * - `tokenAvailable` controls whether getToken() returns Some/None,
+    * - `probeStatus` controls what `headRequest` "returns" — we override
+    *   `isStaleSettingsEntry` wholesale and let `probeStatus` drive the
+    *   simulated probe outcome, so no real network call happens.
+    * - `tokenAvailable` controls whether `getToken()` returns Some/None,
     *   exercising the auto-mode fork. */
   private class ProbeBuilder(
       probeStatus: Option[Int],
@@ -896,8 +896,8 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   ) extends AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
     override protected def getToken(): Option[String] =
       if (tokenAvailable) Some("entra-token") else None
-    // Stub the network call: override probeAndDecide via the helper that
-    // its only call site (isStaleSettingsEntry) consults.
+    // Stub the network call: override isStaleSettingsEntry wholesale so the
+    // simulated probeStatus drives the decision, no actual headRequest fires.
     var probeCalls = 0
     override private[chungmin] def isStaleSettingsEntry(
         uri: URI, host: String, user: String, password: String): Boolean = {
@@ -991,10 +991,10 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  // ─── probeAndDecide via the real implementation (end-to-end) ───────────
+  // ─── probeAndDecideImpl via the real implementation (end-to-end) ───────
 
   // The ProbeBuilder above stubs out the network probe to make the decision
-  // tree directly assertable. This test exercises the REAL probeAndDecide
+  // tree directly assertable. This test exercises the REAL probeAndDecideImpl
   // through buildCredentialsFromMavenSettings + a local socket server, so
   // a future refactor of the real implementation that breaks the decision
   // tree shows up here (rather than only in integration tests).
@@ -1038,7 +1038,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   // ─── probe cache (per-builder, URI-keyed) ──────────────────────────────
 
-  "isStaleSettingsEntry cache" should "actually cache in the real implementation (one probeAndDecide call per URI)" in {
+  "isStaleSettingsEntry cache" should "actually cache in the real implementation (one probeAndDecideImpl call per URI)" in {
     withValidationMode(Some("always")) {
       var calls = 0
       val builder = new AzureDevOpsCredentialsPlugin.CredentialsBuilder(nullLog) {
@@ -1139,14 +1139,14 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
-  // ─── probeAndDecide decision-tree tests ────────────────────────────────
+  // ─── probeAndDecideImpl decision-tree tests ────────────────────────────
 
   // These exercise probeAndDecideImpl's branching logic directly, using
   // stubbed probeWithBasic / probeWithBearer values. The headRequest
   // wire-format and TLS-endpoint-ID invariants are verified by their
   // dedicated tests above.
 
-  "probeAndDecide" should "return false (trust) when network probe returns 200" in {
+  "probeAndDecideImpl" should "return false (trust) when network probe returns 200" in {
     val builder = stubProbeBuilder(
       basicStatus = Some(200), bearerStatus = None, tokenValue = "n/a")
     val uri = new URI("https://pkgs.dev.azure.com/o/p/_packaging/f/maven/v1")
@@ -1225,7 +1225,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
           uri: URI, host: String, token: String): Option[Int] = bearerStatus
     }
 
-  "probeAndDecide (auto, Entra works, Bearer probe succeeds)" should
+  "isStaleSettingsEntry decision tree (auto, Entra works, Bearer probe succeeds)" should
       "return true (drop entry) when the verification probe doesn't get 401" in {
     val builder = stubProbeBuilder(
       basicStatus = Some(401),
@@ -1237,7 +1237,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe true
   }
 
-  "probeAndDecide (auto, Entra works, Bearer probe ALSO 401)" should
+  "isStaleSettingsEntry decision tree (auto, Entra works, Bearer probe ALSO 401)" should
       "return false (keep entry) — the Entra identity has no feed access" in {
     // The bug-1 scenario: stale PAT → 401 on Basic probe; getToken() succeeds
     // via (say) Managed Identity on an Azure VM; but the MI has no access to
@@ -1256,7 +1256,7 @@ class CredentialsBuilderSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       AzureDevOpsCredentialsPlugin.ValidateAuto) shouldBe false
   }
 
-  "probeAndDecide (auto, Bearer verify network error)" should
+  "isStaleSettingsEntry decision tree (auto, Bearer verify network error)" should
       "assume token works (return true, drop entry) — be optimistic on transient blip" in {
     // Basic probe answered with 401 (stale); Bearer-verify fails with a
     // network error (probeWithBearer catches the IOException and returns


### PR DESCRIPTION
## What

**Precedence is unchanged: a `<server>` entry in `~/.m2/settings.xml` still wins over Entra acquisition — *if it works*.**

The only thing this PR adds is a check on whether "works" is actually true. Before trusting an entry, the plugin sends a HEAD probe to the feed with those credentials. If the probe returns anything other than `401`, the entry is trusted and the plugin is a no-op for that feed — same fast path as v0.0.9. If the probe returns `401`, the plugin acquires a fresh Entra token, **verifies that the new token actually works against the feed** (re-probe with Bearer), then drops the entry so the existing Entra path takes over for that feed.

## Why

Pre-0.0.10 `buildCredentialsFromMavenSettings` skipped token acquisition for any feed where settings.xml had an entry, **unconditionally**. A stale entry silently poisoned every `sbt update` until the user manually edited the file — and the failure mode looked like the feed was unreachable, not like the credentials were bad. Probing makes "trust if it works, fall back to Entra if it doesn't" the new default. The user's explicit `<server>` entries still take precedence over Entra; they just have to actually work.

## Behavior matrix (new system property `dev.chungmin.azure.validateExistingCredentials`)

| Mode | Entry works (probe ≠ 401) | Stale (401) + Entra reachable + new token works for feed | Stale + Entra reachable but new token has no feed access | Stale + Entra unreachable |
|---|---|---|---|---|
| `auto` (default) | **Trust entry** (no Entra call for it) | Drop entry, use Entra | Keep entry (Bearer-verify catches it); INFO log about Entra identity scope | Keep entry; INFO log with `az login` remediation |
| `always` | **Trust entry** | Drop entry, use Entra | Drop entry; Entra acquisition succeeds (no Bearer-verify in `always` mode), but the no-access token then 401s at fetch time — sbt/coursier surfaces the fetch error, not the plugin | Drop entry; the subsequent Entra acquisition then fails and the `WARN` from `getTokenImpl` ("failed to get access token. Did you forget to run az login?") surfaces |
| `never` | **Trust entry** | Trust entry | Trust entry | Trust entry (v0.0.9 behavior) |

In all three modes a valid entry is trusted — the modes only differ in how aggressively they recover from stale ones.

Configurable via `-D`, `.jvmopts`, `SBT_OPTS`, or the new `build.sbt` setting key `azureDevOpsValidateExistingCredentials`. The setting key passes mode directly into `CredentialsBuilder` (not via a JVM-global system property bridge, so per-project scoping works correctly).

## Implementation highlights

- **Reuses the raw-socket HEAD helper** introduced in 0.0.9 for realm detection. Extended to take an optional `Authorization` header and parse the status line. No redirects, no header logging — existing PAT-leakage guards apply unchanged. The helper now also refuses an `Authorization` header on any non-https URI (`require`) as defense-in-depth; the production probe path short-circuits the same case earlier via the host/scheme entry-point guard.

- **Bearer-verify pass after Entra acquisition** in `auto` mode: after acquiring a fresh Entra token, the plugin re-probes the feed with that token. If the probe also returns 401, the new token doesn't have feed access either (common on Azure VMs with MI but no ADO access) → keep the stale entry with a clearer diagnostic.

- **Per-builder probe cache** keyed by the FULL feed URI string (not just host). Critical for correctness: ADO serves every org and every feed at the same host, so a host-keyed cache would let the first feed's verdict bleed into every other feed on that host. The cache uses `ConcurrentHashMap.computeIfAbsent` so concurrent first-touch from parallel `credentials` task evaluation doesn't double-probe.

- **Mode passed directly into `CredentialsBuilder`** (new constructor `CredentialsBuilder(log, mode)`) instead of via System.setProperty, and normalized case-insensitively at construction so `"NEVER"`, `"Always"`, etc. behave uniformly across the `-D`/setting-key/legacy-ctor paths.

## Scope

- ADO feed URLs only (`pkgs.dev.azure.com`, `*.pkgs.visualstudio.com`); non-ADO entries are never probed.
- Non-401 responses all trust the entry. Broken-feed detection out of scope.
- Coursier path is fully covered (modern sbt default). Ivy precedence semantics may differ if a user has multiple credentials for the same host across `build.sbt` and `settings.xml` — documented as a limitation.
- User-supplied credentials in `credentials.value` (from `build.sbt`) are NEVER probed — only `settings.xml`-derived ones.
- **Multi-feed-per-host with mixed valid + stale `<server>` entries is a known limitation** (tracked: #7) — pre-existing host-keyed credMap design that this PR does not fix. The probe correctly identifies stale entries, but the downstream credential map still keys by host, so a dropped stale entry can inherit a same-host valid entry's PAT. Documented in README "Limitations" with 3 workarounds. Fixing requires per-resolver credential keying, which is a separate refactor.

## Tests

107 tests total, 100% statement AND branch coverage maintained. New coverage:

- End-to-end probe decision matrix for every cell of the behavior table above (`always` / `auto` / `never` × entry-works / stale-Entra-works / stale-Entra-no-feed-access / stale-Entra-unreachable).
- Case-insensitive mode normalization through both the 2-arg constructor and the legacy single-arg overload.
- Per-URI cache key (not host) — distinct feeds on the same host probe independently.
- `ConcurrentHashMap.computeIfAbsent` atomic-first-touch (no double-probe under concurrency).
- Bearer-verify also-401 path → keep stale entry; Bearer-verify network error → optimistic drop.
- `headRequest` defense-in-depth: throws `IllegalArgumentException` when an Authorization header is supplied for a non-https URI.
- Pure-function `buildHeadRequestLine` covers the wire-format assertion that was previously verified end-to-end against a fake socket.

## Integration test

Live-tested against two sbt-based JVM projects that consume ADO Maven feeds, with `0.0.10-SNAPSHOT` installed locally. Each scenario was run end-to-end via `sbt update`:

| Scenario | Result |
|---|---|
| No `settings.xml`, `az login` valid | ✅ Entra path used (v0.0.9 behavior) |
| Valid `settings.xml` entry | ✅ Trusted; no fallback log |
| Stale `settings.xml` + `mode=auto` (default) | ✅ "settings.xml credentials returned 401; falling through to Entra" + build succeeds |
| Stale `settings.xml` + `mode=never` | ✅ Legacy behavior preserved (entry trusted) |
| Stale `settings.xml` + `build.sbt` setting key `=never` | ✅ Per-project override works without `-D` |
| Entra unreachable (`az` not available) | ⚠️ Inconclusive on the Azure-MI test host; unit tests cover the codepath |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
